### PR TITLE
mlabns: make implementation more flexible

### DIFF
--- a/mlabns/mlabns.go
+++ b/mlabns/mlabns.go
@@ -12,17 +12,17 @@ import (
 	"time"
 )
 
-// httpRequestor is the interface of the implementation that
+// HttpRequestor is the interface of the implementation that
 // performs a mlabns HTTP request for us.
-type httpRequestor interface {
+type HttpRequestor interface {
 	// Do performs the request and returns either a response or
 	// a non-nil error to the caller.
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// httpRequestMaker is the type of the function that
+// HttpRequestMaker is the type of the function that
 // creates a new HTTP request for us.
-type httpRequestMaker = func(
+type HttpRequestMaker = func(
 	method, url string, body io.Reader) (*http.Request, error)
 
 // DefaultTimeout is the default value for Client.Timeout
@@ -46,13 +46,13 @@ type Client struct {
 	// field is initialized by NewClient.
 	UserAgent string
 
-	// requestMaker is the function that creates a request. This is
+	// RequestMaker is the function that creates a request. This is
 	// initialized in NewClient, but you may override it.
-	requestMaker httpRequestMaker
+	RequestMaker HttpRequestMaker
 
-	// requestor is the implementation that performs the request. This is
+	// Requestor is the implementation that performs the request. This is
 	// initialized in NewClient, but you may override it.
-	requestor httpRequestor
+	Requestor HttpRequestor
 }
 
 // baseURL is the default base URL.
@@ -67,8 +67,8 @@ func NewClient(tool, userAgent string) *Client {
 	return &Client{
 		BaseURL:      baseURL,
 		Timeout:      DefaultTimeout,
-		requestMaker: http.NewRequest,
-		requestor:    http.DefaultClient,
+		RequestMaker: http.NewRequest,
+		Requestor:    http.DefaultClient,
 		Tool:         tool,
 		UserAgent:    userAgent,
 	}
@@ -90,7 +90,7 @@ var ErrQueryFailed = errors.New("mlabns returned non-200 status code")
 
 // doGET is an internal function used to perform the request.
 func (c *Client) doGET(ctx context.Context, URL string) ([]byte, error) {
-	request, err := c.requestMaker("GET", URL, nil)
+	request, err := c.RequestMaker("GET", URL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (c *Client) doGET(ctx context.Context, URL string) ([]byte, error) {
 	requestctx, cancel := context.WithTimeout(ctx, c.Timeout)
 	defer cancel()
 	request = request.WithContext(requestctx)
-	response, err := c.requestor.Do(request)
+	response, err := c.Requestor.Do(request)
 	if err != nil {
 		return nil, err
 	}

--- a/mlabns/mlabns.go
+++ b/mlabns/mlabns.go
@@ -60,9 +60,9 @@ const baseURL = "https://locate-dot-mlab-staging.appspot.com/"
 func NewClient(tool, userAgent string) *Client {
 	return &Client{
 		BaseURL:      baseURL,
+		HTTPClient:   http.DefaultClient,
 		Timeout:      DefaultTimeout,
 		RequestMaker: http.NewRequest,
-		HTTPClient:   http.DefaultClient,
 		Tool:         tool,
 		UserAgent:    userAgent,
 	}

--- a/mlabns/mlabns_test.go
+++ b/mlabns/mlabns_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/m-lab/ndt7-client-go/internal/mocks"
@@ -23,7 +24,7 @@ const (
 func TestQueryCommonCase(t *testing.T) {
 	const expectedFQDN = "ndt7-mlab1-nai01.measurementlab.org"
 	client := NewClient(toolName, userAgent)
-	client.Requestor = mocks.NewHTTPRequestor(
+	client.HTTPClient = mocks.NewHTTPClient(
 		200, []byte(fmt.Sprintf(`{"fqdn":"%s"}`, expectedFQDN)), nil,
 	)
 	fqdn, err := client.Query(context.Background())
@@ -65,11 +66,13 @@ func TestQueryNewRequestError(t *testing.T) {
 func TestQueryNetworkError(t *testing.T) {
 	mockedError := errors.New("mocked error")
 	client := NewClient(toolName, userAgent)
-	client.Requestor = mocks.NewHTTPRequestor(
+	client.HTTPClient = mocks.NewHTTPClient(
 		0, []byte{}, mockedError,
 	)
 	_, err := client.Query(context.Background())
-	if err != mockedError {
+	// According to Go docs, the return value of http.Client.Do is always
+	// of type `*url.Error` and wraps the original error.
+	if err.(*url.Error).Err != mockedError {
 		t.Fatal("Not the error we were expecting")
 	}
 }
@@ -78,7 +81,7 @@ func TestQueryNetworkError(t *testing.T) {
 // a non 200 HTTP status code.
 func TestQueryInvalidStatusCode(t *testing.T) {
 	client := NewClient(toolName, userAgent)
-	client.Requestor = mocks.NewHTTPRequestor(
+	client.HTTPClient = mocks.NewHTTPClient(
 		500, []byte{}, nil,
 	)
 	_, err := client.Query(context.Background())
@@ -91,7 +94,7 @@ func TestQueryInvalidStatusCode(t *testing.T) {
 // a JSON parse error.
 func TestQueryJSONParseError(t *testing.T) {
 	client := NewClient(toolName, userAgent)
-	client.Requestor = mocks.NewHTTPRequestor(
+	client.HTTPClient = mocks.NewHTTPClient(
 		200, []byte("{"), nil,
 	)
 	_, err := client.Query(context.Background())
@@ -104,7 +107,7 @@ func TestQueryJSONParseError(t *testing.T) {
 // where no servers are returned.
 func TestQueryNoServers(t *testing.T) {
 	client := NewClient(toolName, userAgent)
-	client.Requestor = mocks.NewHTTPRequestor(
+	client.HTTPClient = mocks.NewHTTPClient(
 		204, []byte(""), nil,
 	)
 	_, err := client.Query(context.Background())

--- a/mlabns/mlabns_test.go
+++ b/mlabns/mlabns_test.go
@@ -23,7 +23,7 @@ const (
 func TestQueryCommonCase(t *testing.T) {
 	const expectedFQDN = "ndt7-mlab1-nai01.measurementlab.org"
 	client := NewClient(toolName, userAgent)
-	client.requestor = mocks.NewHTTPRequestor(
+	client.Requestor = mocks.NewHTTPRequestor(
 		200, []byte(fmt.Sprintf(`{"fqdn":"%s"}`, expectedFQDN)), nil,
 	)
 	fqdn, err := client.Query(context.Background())
@@ -50,7 +50,7 @@ func TestQueryURLError(t *testing.T) {
 func TestQueryNewRequestError(t *testing.T) {
 	mockedError := errors.New("mocked error")
 	client := NewClient(toolName, userAgent)
-	client.requestMaker = func(
+	client.RequestMaker = func(
 		method, url string, body io.Reader) (*http.Request, error,
 	) {
 		return nil, mockedError
@@ -65,7 +65,7 @@ func TestQueryNewRequestError(t *testing.T) {
 func TestQueryNetworkError(t *testing.T) {
 	mockedError := errors.New("mocked error")
 	client := NewClient(toolName, userAgent)
-	client.requestor = mocks.NewHTTPRequestor(
+	client.Requestor = mocks.NewHTTPRequestor(
 		0, []byte{}, mockedError,
 	)
 	_, err := client.Query(context.Background())
@@ -78,7 +78,7 @@ func TestQueryNetworkError(t *testing.T) {
 // a non 200 HTTP status code.
 func TestQueryInvalidStatusCode(t *testing.T) {
 	client := NewClient(toolName, userAgent)
-	client.requestor = mocks.NewHTTPRequestor(
+	client.Requestor = mocks.NewHTTPRequestor(
 		500, []byte{}, nil,
 	)
 	_, err := client.Query(context.Background())
@@ -91,7 +91,7 @@ func TestQueryInvalidStatusCode(t *testing.T) {
 // a JSON parse error.
 func TestQueryJSONParseError(t *testing.T) {
 	client := NewClient(toolName, userAgent)
-	client.requestor = mocks.NewHTTPRequestor(
+	client.Requestor = mocks.NewHTTPRequestor(
 		200, []byte("{"), nil,
 	)
 	_, err := client.Query(context.Background())
@@ -104,7 +104,7 @@ func TestQueryJSONParseError(t *testing.T) {
 // where no servers are returned.
 func TestQueryNoServers(t *testing.T) {
 	client := NewClient(toolName, userAgent)
-	client.requestor = mocks.NewHTTPRequestor(
+	client.Requestor = mocks.NewHTTPRequestor(
 		204, []byte(""), nil,
 	)
 	_, err := client.Query(context.Background())


### PR DESCRIPTION
To this end, expose implementation details that allow to override
the way in which a request is created and serviced.

This is mainly driven by the following OONI needs. When a OONI client
is behind a proxy (e.g. Tor's SOCKS5 proxy), it needs to adjust its
behaviour to still be able to perform ndt7 tests correctly.

To this end, it needs:

1. to contact mlabns using the proxy. In OONI we honour the HTTP_PROXY
environment variable but we also have more specific proxy settings that
are configured through a specialized http.Client. To allow for OONI to
do the latter, this PR exposes the HTTPRequestor publicly, so that we
can override the default with our specialized client. (I can hear an
argument that it's possible to do all of this by just using the proxy
environment variable; yet, we use the specialized client also for
other functionality, including (1) measuring and logging everything
that happens, because we're concerned about censorship and we want
therefore to log what happens at low level; (2) possibly overwriting
DNS resolution to use DoH or alternative name servers. As such we
actually need to have HTTPRequestory public and I don't see how we
can get away with just the HTTP_PROXY environment variable).

2. to modify the mlabns http.Request before it's issued so that it
can append the proper query string arguments. To this end, it needs
to replace the default HTTPRequestMaker with one that calls the
original and then changes the query.

My initial solution to solve the above problems have been vendoring
mlabns, but that's sub-optimal and I'd rather have a more flexible
implementation here. I can also see how others may want to have this
similar kind of flexibility for their packages and/or tests.

See also https://github.com/ooni/probe-engine/commit/dfc0e04dce48ad332e9c0e44ccfd31eb3594f928