### PR TITLE
Sync implementation with ndt7 spec v0.8.0

### DIFF
--- a/cmd/ndt7-client/internal/emitter/batch.go
+++ b/cmd/ndt7-client/internal/emitter/batch.go
@@ -40,39 +40,45 @@ type batchEvent struct {
 }
 
 type batchValue struct {
-	Failure string
-	Server  string
-	Test    string
+	spec.Measurement
+	Failure string `json:",omitempty"`
+	Server  string `json:",omitempty"`
 }
 
 // OnStarting emits the starting event
-func (b Batch) OnStarting(test string) error {
+func (b Batch) OnStarting(test spec.TestKind) error {
 	return b.emitInterface(batchEvent{
 		Key: "starting",
 		Value: batchValue{
-			Test: test,
+			Measurement: spec.Measurement{
+				Test: test,
+			},
 		},
 	})
 }
 
 // OnError emits the error event
-func (b Batch) OnError(test string, err error) error {
+func (b Batch) OnError(test spec.TestKind, err error) error {
 	return b.emitInterface(batchEvent{
 		Key: "error",
 		Value: batchValue{
+			Measurement: spec.Measurement{
+				Test:    test,
+			},
 			Failure: err.Error(),
-			Test:    test,
 		},
 	})
 }
 
 // OnConnected emits the connected event
-func (b Batch) OnConnected(test, fqdn string) error {
+func (b Batch) OnConnected(test spec.TestKind, fqdn string) error {
 	return b.emitInterface(batchEvent{
 		Key: "connected",
 		Value: batchValue{
+			Measurement: spec.Measurement{
+				Test:   test,
+			},
 			Server: fqdn,
-			Test:   test,
 		},
 	})
 }
@@ -94,11 +100,13 @@ func (b Batch) OnUploadEvent(m *spec.Measurement) error {
 }
 
 // OnComplete is the event signalling the end of the test
-func (b Batch) OnComplete(test string) error {
+func (b Batch) OnComplete(test spec.TestKind) error {
 	return b.emitInterface(batchEvent{
 		Key: "complete",
 		Value: batchValue{
-			Test: test,
+			Measurement: spec.Measurement{
+				Test: test,
+			},
 		},
 	})
 }

--- a/cmd/ndt7-client/internal/emitter/batch.go
+++ b/cmd/ndt7-client/internal/emitter/batch.go
@@ -35,44 +35,44 @@ func (b Batch) emitInterface(any interface{}) error {
 }
 
 type batchEvent struct {
-	Key   string      `json:"key"`
-	Value interface{} `json:"value"`
+	Key   string
+	Value interface{}
 }
 
 type batchValue struct {
-	Failure string `json:"failure,omitempty"`
-	Server  string `json:"server,omitempty"`
-	Subtest string `json:"subtest"`
+	Failure string
+	Server  string
+	Test    string
 }
 
 // OnStarting emits the starting event
-func (b Batch) OnStarting(subtest string) error {
+func (b Batch) OnStarting(test string) error {
 	return b.emitInterface(batchEvent{
-		Key: "status.measurement_start",
+		Key: "starting",
 		Value: batchValue{
-			Subtest: subtest,
+			Test: test,
 		},
 	})
 }
 
 // OnError emits the error event
-func (b Batch) OnError(subtest string, err error) error {
+func (b Batch) OnError(test string, err error) error {
 	return b.emitInterface(batchEvent{
-		Key: "failure.measurement",
+		Key: "error",
 		Value: batchValue{
 			Failure: err.Error(),
-			Subtest: subtest,
+			Test:    test,
 		},
 	})
 }
 
 // OnConnected emits the connected event
-func (b Batch) OnConnected(subtest, fqdn string) error {
+func (b Batch) OnConnected(test, fqdn string) error {
 	return b.emitInterface(batchEvent{
-		Key: "status.measurement_begin",
+		Key: "connected",
 		Value: batchValue{
-			Server:  fqdn,
-			Subtest: subtest,
+			Server: fqdn,
+			Test:   test,
 		},
 	})
 }
@@ -93,12 +93,12 @@ func (b Batch) OnUploadEvent(m *spec.Measurement) error {
 	})
 }
 
-// OnComplete is the event signalling the end of the subtest
-func (b Batch) OnComplete(subtest string) error {
+// OnComplete is the event signalling the end of the test
+func (b Batch) OnComplete(test string) error {
 	return b.emitInterface(batchEvent{
-		Key: "status.measurement_done",
+		Key: "complete",
 		Value: batchValue{
-			Subtest: subtest,
+			Test: test,
 		},
 	})
 }

--- a/cmd/ndt7-client/internal/emitter/emitter.go
+++ b/cmd/ndt7-client/internal/emitter/emitter.go
@@ -13,13 +13,13 @@ import "github.com/m-lab/ndt7-client-go/spec"
 // on the sequence in which events may occur.
 type Emitter interface {
 	// OnStarting is emitted before attempting to start a test.
-	OnStarting(test string) error
+	OnStarting(test spec.TestKind) error
 
 	// OnError is emitted if a test cannot start.
-	OnError(test string, err error) error
+	OnError(test spec.TestKind, err error) error
 
 	// OnConnected is emitted when we connected to the ndt7 server.
-	OnConnected(test, fqdn string) error
+	OnConnected(test spec.TestKind, fqdn string) error
 
 	// OnDownloadEvent is emitted during the download.
 	OnDownloadEvent(m *spec.Measurement) error
@@ -28,5 +28,5 @@ type Emitter interface {
 	OnUploadEvent(m *spec.Measurement) error
 
 	// OnComplete is always emitted when the test is over.
-	OnComplete(test string) error
+	OnComplete(test spec.TestKind) error
 }

--- a/cmd/ndt7-client/internal/emitter/emitter.go
+++ b/cmd/ndt7-client/internal/emitter/emitter.go
@@ -12,14 +12,14 @@ import "github.com/m-lab/ndt7-client-go/spec"
 // See the documentation of the main package for more details
 // on the sequence in which events may occur.
 type Emitter interface {
-	// OnStarting is emitted before attempting to start a subtest.
-	OnStarting(subtest string) error
+	// OnStarting is emitted before attempting to start a test.
+	OnStarting(test string) error
 
-	// OnError is emitted if a subtest cannot start.
-	OnError(subtest string, err error) error
+	// OnError is emitted if a test cannot start.
+	OnError(test string, err error) error
 
 	// OnConnected is emitted when we connected to the ndt7 server.
-	OnConnected(subtest, fqdn string) error
+	OnConnected(test, fqdn string) error
 
 	// OnDownloadEvent is emitted during the download.
 	OnDownloadEvent(m *spec.Measurement) error
@@ -27,6 +27,6 @@ type Emitter interface {
 	// OnUploadEvent is emitted during the upload.
 	OnUploadEvent(m *spec.Measurement) error
 
-	// OnComplete is always emitted when the subtest is over.
-	OnComplete(subtest string) error
+	// OnComplete is always emitted when the test is over.
+	OnComplete(test string) error
 }

--- a/cmd/ndt7-client/internal/emitter/interactive.go
+++ b/cmd/ndt7-client/internal/emitter/interactive.go
@@ -21,19 +21,19 @@ func NewInteractive() Interactive {
 }
 
 // OnStarting handles the start event
-func (i Interactive) OnStarting(test string) error {
+func (i Interactive) OnStarting(test spec.TestKind) error {
 	_, err := fmt.Fprintf(i.out, "\rstarting %s", test)
 	return err
 }
 
 // OnError handles the error event
-func (i Interactive) OnError(test string, err error) error {
+func (i Interactive) OnError(test spec.TestKind, err error) error {
 	_, failure := fmt.Fprintf(i.out, "\r%s failed: %s\n", test, err.Error())
 	return failure
 }
 
 // OnConnected handles the connected event
-func (i Interactive) OnConnected(test, fqdn string) error {
+func (i Interactive) OnConnected(test spec.TestKind, fqdn string) error {
 	_, err := fmt.Fprintf(i.out, "\r%s in progress with %s\n", test, fqdn)
 	return err
 }
@@ -65,7 +65,7 @@ func (i Interactive) onSpeedEvent(m *spec.Measurement) error {
 }
 
 // OnComplete handles the complete event
-func (i Interactive) OnComplete(test string) error {
+func (i Interactive) OnComplete(test spec.TestKind) error {
 	_, err := fmt.Fprintf(i.out, "\n%s: complete\n", test)
 	return err
 }

--- a/cmd/ndt7-client/internal/emitter/interactive.go
+++ b/cmd/ndt7-client/internal/emitter/interactive.go
@@ -21,47 +21,51 @@ func NewInteractive() Interactive {
 }
 
 // OnStarting handles the start event
-func (i Interactive) OnStarting(subtest string) error {
-	_, err := fmt.Fprintf(i.out, "\rstarting %s", subtest)
+func (i Interactive) OnStarting(test string) error {
+	_, err := fmt.Fprintf(i.out, "\rstarting %s", test)
 	return err
 }
 
 // OnError handles the error event
-func (i Interactive) OnError(subtest string, err error) error {
-	_, failure := fmt.Fprintf(i.out, "\r%s failed: %s\n", subtest, err.Error())
+func (i Interactive) OnError(test string, err error) error {
+	_, failure := fmt.Fprintf(i.out, "\r%s failed: %s\n", test, err.Error())
 	return failure
 }
 
 // OnConnected handles the connected event
-func (i Interactive) OnConnected(subtest, fqdn string) error {
-	_, err := fmt.Fprintf(i.out, "\r%s in progress with %s\n", subtest, fqdn)
+func (i Interactive) OnConnected(test, fqdn string) error {
+	_, err := fmt.Fprintf(i.out, "\r%s in progress with %s\n", test, fqdn)
 	return err
 }
 
-// OnDownloadEvent handles an event emitted by the download subtest
+// OnDownloadEvent handles an event emitted by the download test
 func (i Interactive) OnDownloadEvent(m *spec.Measurement) error {
-	_, err := fmt.Fprintf(i.out,
-		"\rMaxBandwidth: %7.1f Mbit/s - RTT: %4.0f/%4.0f/%4.0f (min/smoothed/var) ms",
-		float64(m.BBRInfo.MaxBandwidth)/(1000.0*1000.0),
-		m.BBRInfo.MinRTT,
-		m.TCPInfo.SmoothedRTT,
-		m.TCPInfo.RTTVar,
-	)
-	return err
+	return i.onSpeedEvent(m)
 }
 
-// OnUploadEvent handles an event emittd during the upload subtest
+// OnUploadEvent handles an event emitted during the upload test
 func (i Interactive) OnUploadEvent(m *spec.Measurement) error {
-	if m.Elapsed <= 0.0 {
-		return errors.New("Negative or zero m.Elapsed")
+	return i.onSpeedEvent(m)
+}
+
+func (i Interactive) onSpeedEvent(m *spec.Measurement) error {
+	// The specification recommends that we show application level
+	// measurements. Let's just do that in interactive mode. To this
+	// end, we ignore any measurement coming from the server.
+	if m.Origin != spec.OriginClient {
+		return nil
 	}
-	v := (8.0 * float64(m.AppInfo.NumBytes)) / m.Elapsed / (1000.0 * 1000.0)
+	if m.AppInfo == nil || m.AppInfo.ElapsedTime <= 0 {
+		return errors.New("Missing m.AppInfo or invalid m.AppInfo.ElapsedTime")
+	}
+	elapsed := float64(m.AppInfo.ElapsedTime) / 1e06
+	v := (8.0 * float64(m.AppInfo.NumBytes)) / elapsed / (1000.0 * 1000.0)
 	_, err := fmt.Fprintf(i.out, "\rAvg. speed  : %7.1f Mbit/s", v)
 	return err
 }
 
 // OnComplete handles the complete event
-func (i Interactive) OnComplete(subtest string) error {
-	_, err := fmt.Fprintf(i.out, "\n%s: complete\n", subtest)
+func (i Interactive) OnComplete(test string) error {
+	_, err := fmt.Fprintf(i.out, "\n%s: complete\n", test)
 	return err
 }

--- a/cmd/ndt7-client/internal/mocks/mocks_test.go
+++ b/cmd/ndt7-client/internal/mocks/mocks_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 )
 
-// TestFailingWriter verifies that the FailingWriter always fails.
 func TestFailingWriter(t *testing.T) {
 	wr := FailingWriter{}
 	n, err := wr.Write([]byte("abc"))
@@ -17,7 +16,6 @@ func TestFailingWriter(t *testing.T) {
 	}
 }
 
-// TestSavingWriter verifies that SavingWriter works.
 func TestSavingWriter(t *testing.T) {
 	sw := &SavingWriter{}
 	first := []byte("abc")

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -100,7 +100,7 @@ type runner struct {
 }
 
 func (r runner) doRunTest(
-	ctx context.Context, test string,
+	ctx context.Context, test spec.TestKind,
 	start func(context.Context) (<-chan spec.Measurement, error),
 	emitEvent func(m *spec.Measurement) error,
 ) int {
@@ -123,7 +123,7 @@ func (r runner) doRunTest(
 }
 
 func (r runner) runTest(
-	ctx context.Context, test string,
+	ctx context.Context, test spec.TestKind,
 	start func(context.Context) (<-chan spec.Measurement, error),
 	emitEvent func(m *spec.Measurement) error,
 ) int {
@@ -143,12 +143,12 @@ func (r runner) runTest(
 }
 
 func (r runner) runDownload(ctx context.Context) int {
-	return r.runTest(ctx, "download", r.client.StartDownload,
+	return r.runTest(ctx, spec.TestDownload, r.client.StartDownload,
 		r.emitter.OnDownloadEvent)
 }
 
 func (r runner) runUpload(ctx context.Context) int {
-	return r.runTest(ctx, "upload", r.client.StartUpload,
+	return r.runTest(ctx, spec.TestUpload, r.client.StartUpload,
 		r.emitter.OnUploadEvent)
 }
 

--- a/cmd/ndt7-client/main_test.go
+++ b/cmd/ndt7-client/main_test.go
@@ -72,15 +72,15 @@ type mockedEmitter struct {
 	CompleteError  error
 }
 
-func (me mockedEmitter) OnStarting(test string) error {
+func (me mockedEmitter) OnStarting(test spec.TestKind) error {
 	return me.StartingError
 }
 
-func (mockedEmitter) OnError(test string, err error) error {
+func (mockedEmitter) OnError(test spec.TestKind, err error) error {
 	return nil
 }
 
-func (me mockedEmitter) OnConnected(test, fqdn string) error {
+func (me mockedEmitter) OnConnected(test spec.TestKind, fqdn string) error {
 	return me.ConnectedError
 }
 
@@ -92,7 +92,7 @@ func (mockedEmitter) OnUploadEvent(m *spec.Measurement) error {
 	return nil
 }
 
-func (me mockedEmitter) OnComplete(test string) error {
+func (me mockedEmitter) OnComplete(test spec.TestKind) error {
 	return me.CompleteError
 }
 

--- a/cmd/ndt7-client/main_test.go
+++ b/cmd/ndt7-client/main_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/m-lab/ndt7-client-go/spec"
 )
 
-// TestNormalUsage tests ndt7-client w/o any command line arguments.
 func TestNormalUsage(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
@@ -31,7 +30,6 @@ func TestNormalUsage(t *testing.T) {
 	}
 }
 
-// TestBatchUsage tests the -batch use case.
 func TestBatchUsage(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
@@ -50,7 +48,6 @@ func TestBatchUsage(t *testing.T) {
 	}
 }
 
-// TestDownloadError tests the case where a subtest fails.
 func TestDownloadError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
@@ -75,15 +72,15 @@ type mockedEmitter struct {
 	CompleteError  error
 }
 
-func (me mockedEmitter) OnStarting(subtest string) error {
+func (me mockedEmitter) OnStarting(test string) error {
 	return me.StartingError
 }
 
-func (mockedEmitter) OnError(subtest string, err error) error {
+func (mockedEmitter) OnError(test string, err error) error {
 	return nil
 }
 
-func (me mockedEmitter) OnConnected(subtest, fqdn string) error {
+func (me mockedEmitter) OnConnected(test, fqdn string) error {
 	return me.ConnectedError
 }
 
@@ -95,22 +92,20 @@ func (mockedEmitter) OnUploadEvent(m *spec.Measurement) error {
 	return nil
 }
 
-func (me mockedEmitter) OnComplete(subtest string) error {
+func (me mockedEmitter) OnComplete(test string) error {
 	return me.CompleteError
 }
 
-// TestRunSubtestOnStartingError deals with the case where
-// the emitter.OnStarting function fails.
-func TestRunSubtestOnStartingError(t *testing.T) {
+func TestRunTestOnStartingError(t *testing.T) {
 	runner := runner{
 		client: ndt7.NewClient(clientName, clientVersion),
 		emitter: mockedEmitter{
 			StartingError: errors.New("mocked error"),
 		},
 	}
-	code := runner.runSubtest(
+	code := runner.runTest(
 		context.Background(),
-		"subtest",
+		"download",
 		func(context.Context) (<-chan spec.Measurement, error) {
 			out := make(chan spec.Measurement)
 			close(out)
@@ -125,18 +120,16 @@ func TestRunSubtestOnStartingError(t *testing.T) {
 	}
 }
 
-// TestRunSubtestOnConnectedError deals with the case where
-// the emitter.OnConnected function fails.
-func TestRunSubtestOnConnectedError(t *testing.T) {
+func TestRunTestOnConnectedError(t *testing.T) {
 	runner := runner{
 		client: ndt7.NewClient(clientName, clientVersion),
 		emitter: mockedEmitter{
 			ConnectedError: errors.New("mocked error"),
 		},
 	}
-	code := runner.runSubtest(
+	code := runner.runTest(
 		context.Background(),
-		"subtest",
+		"download",
 		func(context.Context) (<-chan spec.Measurement, error) {
 			out := make(chan spec.Measurement)
 			close(out)
@@ -151,18 +144,16 @@ func TestRunSubtestOnConnectedError(t *testing.T) {
 	}
 }
 
-// TestRunSubtestOnCompleteError deals with the case where
-// the emitter.OnComplete function fails.
-func TestRunSubtestOnCompleteError(t *testing.T) {
+func TestRunTestOnCompleteError(t *testing.T) {
 	runner := runner{
 		client: ndt7.NewClient(clientName, clientVersion),
 		emitter: mockedEmitter{
 			CompleteError: errors.New("mocked error"),
 		},
 	}
-	code := runner.runSubtest(
+	code := runner.runTest(
 		context.Background(),
-		"subtest",
+		"download",
 		func(context.Context) (<-chan spec.Measurement, error) {
 			out := make(chan spec.Measurement)
 			close(out)
@@ -177,16 +168,14 @@ func TestRunSubtestOnCompleteError(t *testing.T) {
 	}
 }
 
-// TestRunSubtestEmitEventError deals with the case where
-// the emitEvent function fails.
-func TestRunSubtestEmitEventError(t *testing.T) {
+func TestRunTestEmitEventError(t *testing.T) {
 	runner := runner{
 		client:  ndt7.NewClient(clientName, clientVersion),
 		emitter: mockedEmitter{},
 	}
-	code := runner.runSubtest(
+	code := runner.runTest(
 		context.Background(),
-		"subtest",
+		"download",
 		func(context.Context) (<-chan spec.Measurement, error) {
 			out := make(chan spec.Measurement)
 			go func() {
@@ -204,9 +193,6 @@ func TestRunSubtestEmitEventError(t *testing.T) {
 	}
 }
 
-// TestBatchEmitterEventsOrderNormal ensures that events are
-// emitted in the order mentioned in main.go docs, when we are
-// in the common case (i.e. no errors).
 func TestBatchEmitterEventsOrderNormal(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
@@ -216,7 +202,7 @@ func TestBatchEmitterEventsOrderNormal(t *testing.T) {
 		client:  ndt7.NewClient(clientName, clientVersion),
 		emitter: emitter.Batch{Writer: writer},
 	}
-	code := runner.runSubtest(
+	code := runner.runTest(
 		context.Background(),
 		"download",
 		runner.client.StartDownload,
@@ -231,18 +217,18 @@ func TestBatchEmitterEventsOrderNormal(t *testing.T) {
 	}
 	for lineno, data := range writer.Data {
 		var m struct {
-			Key string `json:"key"`
+			Key string
 		}
 		err := json.Unmarshal(data, &m)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if lineno == 0 {
-			if m.Key != "status.measurement_start" {
+			if m.Key != "starting" {
 				t.Fatal("unexpected first key")
 			}
 		} else if lineno == 1 {
-			if m.Key != "status.measurement_begin" {
+			if m.Key != "connected" {
 				t.Fatal("unexpected second key")
 			}
 		} else if lineno < numLines-1 {
@@ -251,7 +237,7 @@ func TestBatchEmitterEventsOrderNormal(t *testing.T) {
 					lineno, m.Key)
 			}
 		} else if lineno == numLines-1 {
-			if m.Key != "status.measurement_done" {
+			if m.Key != "complete" {
 				t.Fatal("unexpected last key")
 			}
 		} else {
@@ -260,9 +246,6 @@ func TestBatchEmitterEventsOrderNormal(t *testing.T) {
 	}
 }
 
-// TestBatchEmitterEventsOrderFailure ensures that events are
-// emitted in the order mentioned in main.go docs, when we are
-// in the failure case (e.g. we cannot connect).
 func TestBatchEmitterEventsOrderFailure(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
@@ -273,7 +256,7 @@ func TestBatchEmitterEventsOrderFailure(t *testing.T) {
 		emitter: emitter.Batch{Writer: writer},
 	}
 	runner.client.MLabNSClient.BaseURL = "\t" // URL parser error
-	code := runner.runSubtest(
+	code := runner.runTest(
 		context.Background(),
 		"download",
 		runner.client.StartDownload,
@@ -288,7 +271,7 @@ func TestBatchEmitterEventsOrderFailure(t *testing.T) {
 	}
 	for lineno, data := range writer.Data {
 		var m struct {
-			Key string `json:"key"`
+			Key string
 		}
 		err := json.Unmarshal(data, &m)
 		if err != nil {
@@ -296,15 +279,15 @@ func TestBatchEmitterEventsOrderFailure(t *testing.T) {
 		}
 		fmt.Printf("%d - %s\n", lineno, m.Key)
 		if lineno == 0 {
-			if m.Key != "status.measurement_start" {
+			if m.Key != "starting" {
 				t.Fatal("unexpected first key")
 			}
 		} else if lineno == 1 {
-			if m.Key != "failure.measurement" {
+			if m.Key != "error" {
 				t.Fatal("unexpected second key")
 			}
 		} else if lineno == 2 {
-			if m.Key != "status.measurement_done" {
+			if m.Key != "complete" {
 				t.Fatal("unexpected third key")
 			}
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/m-lab/ndt7-client-go
 
 go 1.12
 
-require github.com/gorilla/websocket v1.4.0
+require (
+	github.com/gorilla/websocket v1.4.0
+	github.com/m-lab/ndt-server v0.13.2-0.20190920160430-5b7940b72f0d
+	github.com/m-lab/tcp-info v1.1.0
+)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/gorilla/websocket v1.4.0
-	github.com/m-lab/ndt-server v0.13.2-0.20190920160430-5b7940b72f0d
+	github.com/m-lab/ndt-server v0.13.2
 	github.com/m-lab/tcp-info v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/m-lab/ndt-server v0.13.1 h1:E5y0bd90spaRnA/iErYsaL1MdHBS0cSrqIoaJ/dCdeY=
+github.com/m-lab/ndt-server v0.13.1/go.mod h1:ZLVRCEbCBkhh0pwNjnLpwaZnHOHGEH76H/fzIIVFRWw=
+github.com/m-lab/ndt-server v0.13.2-0.20190920160430-5b7940b72f0d h1:+8+Pi5mgMHJwXdAIFHTwNi1wIo7r94ZgV1nyy6HsMaM=
+github.com/m-lab/ndt-server v0.13.2-0.20190920160430-5b7940b72f0d/go.mod h1:ZLVRCEbCBkhh0pwNjnLpwaZnHOHGEH76H/fzIIVFRWw=
+github.com/m-lab/tcp-info v1.1.0 h1:+IzCxTd/IVRjt+EXyi4Nj1bIhuX/iftbQCFB2itrB8M=
+github.com/m-lab/tcp-info v1.1.0/go.mod h1:bkvI4qbjB6QVC2tsLSHqf5OnIYcmuLEVjo7+8YA56Kg=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/m-lab/ndt-server v0.13.1 h1:E5y0bd90spaRnA/iErYsaL1MdHBS0cSrqIoaJ/dCdeY=
-github.com/m-lab/ndt-server v0.13.1/go.mod h1:ZLVRCEbCBkhh0pwNjnLpwaZnHOHGEH76H/fzIIVFRWw=
-github.com/m-lab/ndt-server v0.13.2-0.20190920160430-5b7940b72f0d h1:+8+Pi5mgMHJwXdAIFHTwNi1wIo7r94ZgV1nyy6HsMaM=
-github.com/m-lab/ndt-server v0.13.2-0.20190920160430-5b7940b72f0d/go.mod h1:ZLVRCEbCBkhh0pwNjnLpwaZnHOHGEH76H/fzIIVFRWw=
+github.com/m-lab/ndt-server v0.13.2 h1:ISasCjeOXaKcHjRo//Q2A2THbwoC2Pp01d8a2OnPC6Y=
+github.com/m-lab/ndt-server v0.13.2/go.mod h1:ZLVRCEbCBkhh0pwNjnLpwaZnHOHGEH76H/fzIIVFRWw=
 github.com/m-lab/tcp-info v1.1.0 h1:+IzCxTd/IVRjt+EXyi4Nj1bIhuX/iftbQCFB2itrB8M=
 github.com/m-lab/tcp-info v1.1.0/go.mod h1:bkvI4qbjB6QVC2tsLSHqf5OnIYcmuLEVjo7+8YA56Kg=

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -16,7 +16,8 @@ import (
 // download time expires. Uses the provided websocket connection. Emits zero
 // or more measurements to the provided channel. Returns the error that caused
 // the download loop to stop, which is mainly useful when testing, since the
-// normal usage of this function is to be run in a separate goroutine.
+// normal usage of this function is to be run in a separate goroutine. Note
+// that this function would block if you don't read from the channel.
 //
 // Note that this function closes conn and ch when exiting.
 func Run(ctx context.Context, conn websocketx.Conn, ch chan<- spec.Measurement) error {

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -12,22 +12,25 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/m-lab/ndt7-client-go/internal/mocks"
 	"github.com/m-lab/ndt7-client-go/spec"
+	"github.com/m-lab/tcp-info/tcp"
 )
 
-// TestReadText is the case where we read text messages.
 func TestReadText(t *testing.T) {
 	orig := spec.Measurement{
-		AppInfo: spec.AppInfo{
-			NumBytes: 1234,
+		AppInfo: &spec.AppInfo{
+			ElapsedTime: 1234000,
+			NumBytes:    1234,
 		},
-		BBRInfo: spec.BBRInfo{
+		BBRInfo: &spec.BBRInfo{
 			MaxBandwidth: 12345,
-			MinRTT:       1.2345,
+			MinRTT:       12345,
 		},
-		Elapsed: 1.234,
-		TCPInfo: spec.TCPInfo{
-			SmoothedRTT: 1.2345,
-			RTTVar:      1.2345,
+		TCPInfo: &spec.TCPInfo{
+			ElapsedTime: 1234000,
+			LinuxTCPInfo: tcp.LinuxTCPInfo{
+				RTT:    12345000,
+				RTTVar: 12345000,
+			},
 		},
 	}
 	data, err := json.Marshal(orig)
@@ -52,15 +55,20 @@ func TestReadText(t *testing.T) {
 	tot := 0
 	for m := range outch {
 		tot++
+		if m.Origin == spec.OriginClient {
+			// We test this specific case in another test. Just do not
+			// fallthrough because we're gonna fail otherwise.
+			continue
+		}
 		if m.Origin != spec.OriginServer {
 			t.Fatal("The origin is invalid")
 		}
-		if m.Direction != spec.DirectionDownload {
-			t.Fatal("The direction is invalid")
+		if m.Test != spec.TestDownload {
+			t.Fatal("The test is invalid")
 		}
 		// clear origin and direction for DeepEqual to work
 		m.Origin = ""
-		m.Direction = ""
+		m.Test = ""
 		if !reflect.DeepEqual(orig, m) {
 			t.Fatal("The two structs differ")
 		}
@@ -70,7 +78,6 @@ func TestReadText(t *testing.T) {
 	}
 }
 
-// TestReadBinary is the case where we read binary messages.
 func TestReadBinary(t *testing.T) {
 	outch := make(chan spec.Measurement)
 	ctx, cancel := context.WithTimeout(
@@ -87,13 +94,29 @@ func TestReadBinary(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	for range outch {
-		t.Fatal("We didn't expect a measurement here")
+	prev := spec.Measurement{
+		AppInfo: &spec.AppInfo{},
+	}
+	for m := range outch {
+		if m.Origin != spec.OriginClient {
+			t.Fatal("unexpected measurement origin")
+		}
+		if m.Test != spec.TestDownload {
+			t.Fatal("unexpected test name")
+		}
+		if m.AppInfo == nil {
+			t.Fatal("m.AppInfo is nil")
+		}
+		if m.AppInfo.ElapsedTime <= prev.AppInfo.ElapsedTime {
+			t.Fatal("the time is not increasing")
+		}
+		if m.AppInfo.NumBytes <= prev.AppInfo.NumBytes {
+			t.Fatal("the number of bytes is not increasing")
+		}
+		prev = m
 	}
 }
 
-// TestSetReadDeadlineError is the case where we get
-// an error when setting the read deadline.
 func TestSetReadDeadlineError(t *testing.T) {
 	outch := make(chan spec.Measurement)
 	ctx, cancel := context.WithTimeout(
@@ -117,8 +140,6 @@ func TestSetReadDeadlineError(t *testing.T) {
 	}
 }
 
-// TestReadMessageError is the case where the
-// ReadMessage method fails
 func TestReadMessageError(t *testing.T) {
 	outch := make(chan spec.Measurement)
 	ctx, cancel := context.WithTimeout(
@@ -142,8 +163,6 @@ func TestReadMessageError(t *testing.T) {
 	}
 }
 
-// TestReadInvalidJSON is the case where we read
-// an invalid JSON message.
 func TestReadInvalidJSON(t *testing.T) {
 	outch := make(chan spec.Measurement)
 	ctx, cancel := context.WithTimeout(

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/m-lab/ndt7-client-go/spec"
 )
 
-// TestNormal is the normal test case
 func TestNormal(t *testing.T) {
 	outch := make(chan spec.Measurement)
 	ctx, cancel := context.WithTimeout(
@@ -25,17 +24,22 @@ func TestNormal(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	prev := spec.Measurement{}
+	prev := spec.Measurement{
+		AppInfo: &spec.AppInfo{},
+	}
 	tot := 0
 	for m := range outch {
 		tot++
 		if m.Origin != spec.OriginClient {
 			t.Fatal("The origin is wrong")
 		}
-		if m.Direction != spec.DirectionUpload {
-			t.Fatal("The direction is wrong")
+		if m.Test != spec.TestUpload {
+			t.Fatal("The test is wrong")
 		}
-		if m.Elapsed <= prev.Elapsed {
+		if m.AppInfo == nil {
+			t.Fatal("m.AppInfo is nil")
+		}
+		if m.AppInfo.ElapsedTime <= prev.AppInfo.ElapsedTime {
 			t.Fatal("Time is not increasing")
 		}
 		// Note: it can stay constant when we're servicing
@@ -50,8 +54,6 @@ func TestNormal(t *testing.T) {
 	}
 }
 
-// TestSetReadDealineError ensures that we deal with
-// the case where SetReadDeadline fails.
 func TestSetReadDeadlineError(t *testing.T) {
 	mockedErr := errors.New("mocked error")
 	conn := mocks.Conn{
@@ -63,8 +65,6 @@ func TestSetReadDeadlineError(t *testing.T) {
 	}
 }
 
-// TestReadMessageError ensures that we deal with
-// the case where ReadMessage fails.
 func TestReadMessageError(t *testing.T) {
 	mockedErr := errors.New("mocked error")
 	conn := mocks.Conn{
@@ -76,8 +76,6 @@ func TestReadMessageError(t *testing.T) {
 	}
 }
 
-// TestReadNonTextMessageError ensures that we deal with the
-// case where ReadMessage returns a non text message.
 func TestReadNonTextMessageError(t *testing.T) {
 	conn := mocks.Conn{
 		ReadMessageType:      websocket.BinaryMessage,
@@ -89,8 +87,6 @@ func TestReadNonTextMessageError(t *testing.T) {
 	}
 }
 
-// TestMakePreparedMessageError ensures that we deal with
-// the case where makePreparedMessage fails.
 func TestMakePreparedMessageError(t *testing.T) {
 	mockedErr := errors.New("mocked error")
 	outch := make(chan int64)
@@ -115,8 +111,6 @@ func TestMakePreparedMessageError(t *testing.T) {
 	}
 }
 
-// TestSetWriteDeadlineError ensures that we deal with
-// the case where SetWriteDeadline fails.
 func TestSetWriteDeadlineError(t *testing.T) {
 	mockedErr := errors.New("mocked error")
 	outch := make(chan int64)
@@ -138,8 +132,6 @@ func TestSetWriteDeadlineError(t *testing.T) {
 	}
 }
 
-// TestWritePreparedMessageError ensures that we deal with
-// the case where WritePreparedMessage fails.
 func TestWritePreparedMessageError(t *testing.T) {
 	mockedErr := errors.New("mocked error")
 	outch := make(chan int64)

--- a/mlabns/mlabns_test.go
+++ b/mlabns/mlabns_test.go
@@ -13,14 +13,10 @@ import (
 )
 
 const (
-	// toolName is the tool name that we use in this file.
-	toolName = "ndt7"
-
-	// userAgent is the user agent that we use in this file.
+	toolName  = "ndt7"
 	userAgent = "ndt7-client-go/0.1.0"
 )
 
-// TestQueryCommonCase tests the common case.
 func TestQueryCommonCase(t *testing.T) {
 	const expectedFQDN = "ndt7-mlab1-nai01.measurementlab.org"
 	client := NewClient(toolName, userAgent)
@@ -36,7 +32,6 @@ func TestQueryCommonCase(t *testing.T) {
 	}
 }
 
-// TestQueryURLError ensures we deal with an invalid URL.
 func TestQueryURLError(t *testing.T) {
 	client := NewClient(toolName, userAgent)
 	client.BaseURL = "\t" // breaks the parser
@@ -46,8 +41,6 @@ func TestQueryURLError(t *testing.T) {
 	}
 }
 
-// TestQueryNewRequestError ensures we deal
-// with an http.NewRequest errors.
 func TestQueryNewRequestError(t *testing.T) {
 	mockedError := errors.New("mocked error")
 	client := NewClient(toolName, userAgent)
@@ -62,7 +55,6 @@ func TestQueryNewRequestError(t *testing.T) {
 	}
 }
 
-// TestQueryNetworkError ensures we deal with network errors.
 func TestQueryNetworkError(t *testing.T) {
 	mockedError := errors.New("mocked error")
 	client := NewClient(toolName, userAgent)
@@ -77,8 +69,6 @@ func TestQueryNetworkError(t *testing.T) {
 	}
 }
 
-// TestQueryInvalidStatusCode ensures we deal with
-// a non 200 HTTP status code.
 func TestQueryInvalidStatusCode(t *testing.T) {
 	client := NewClient(toolName, userAgent)
 	client.HTTPClient = mocks.NewHTTPClient(
@@ -90,8 +80,6 @@ func TestQueryInvalidStatusCode(t *testing.T) {
 	}
 }
 
-// TestQueryJSONParseError ensures we deal with
-// a JSON parse error.
 func TestQueryJSONParseError(t *testing.T) {
 	client := NewClient(toolName, userAgent)
 	client.HTTPClient = mocks.NewHTTPClient(
@@ -103,8 +91,6 @@ func TestQueryJSONParseError(t *testing.T) {
 	}
 }
 
-// TestQueryNoServer ensures we deal with the case
-// where no servers are returned.
 func TestQueryNoServers(t *testing.T) {
 	client := NewClient(toolName, userAgent)
 	client.HTTPClient = mocks.NewHTTPClient(
@@ -116,7 +102,6 @@ func TestQueryNoServers(t *testing.T) {
 	}
 }
 
-// TestIntegration is an integration test for mlabns
 func TestIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")

--- a/ndt7.go
+++ b/ndt7.go
@@ -44,8 +44,8 @@ type connectFn = func(
 	requestHeader http.Header,
 ) (*websocket.Conn, *http.Response, error)
 
-// subtestFn is the type of the function running a subtest.
-type subtestFn = func(
+// testFn is the type of the function running a test.
+type testFn = func(
 	ctx context.Context, conn websocketx.Conn, ch chan<- spec.Measurement,
 ) error
 
@@ -80,17 +80,17 @@ type Client struct {
 	// NewClient, but you may override it.
 	connect connectFn
 
-	// download is the function running the download subtest. We
+	// download is the function running the download test. We
 	// set it in NewClient and you may override it.
-	download subtestFn
+	download testFn
 
 	// locate is the optional function to locate a ndt7 server using
 	// the mlab-ns service. This function is set to its default value
 	// by NewClient, but you may want to override it.
 	locate locateFn
 
-	// upload is like download but for the upload subtest.
-	upload subtestFn
+	// upload is like download but for the upload test.
+	upload testFn
 }
 
 // makeUserAgent creates the user agent string
@@ -151,8 +151,8 @@ func (c *Client) doConnect(ctx context.Context, URLPath string) (*websocket.Conn
 	return conn, err
 }
 
-// start is the function for starting a subtest.
-func (c *Client) start(ctx context.Context, f subtestFn, p string) (<-chan spec.Measurement, error) {
+// start is the function for starting a test.
+func (c *Client) start(ctx context.Context, f testFn, p string) (<-chan spec.Measurement, error) {
 	if c.FQDN == "" {
 		fqdn, err := c.discoverServer(ctx)
 		if err != nil {

--- a/ndt7_test.go
+++ b/ndt7_test.go
@@ -16,8 +16,6 @@ const (
 	clientVersion = "0.1.0"
 )
 
-// newMockedClient returns a mocked client that does nothing
-// except pretending it is doing something.
 func newMockedClient(ctx context.Context) *Client {
 	client := NewClient(clientName, clientVersion)
 	// Override locate to return a fake IP address
@@ -44,7 +42,6 @@ func newMockedClient(ctx context.Context) *Client {
 	return client
 }
 
-// TestDownloadCase tests the download case.
 func TestDownloadCase(t *testing.T) {
 	ctx := context.Background()
 	client := newMockedClient(ctx)
@@ -57,7 +54,6 @@ func TestDownloadCase(t *testing.T) {
 	}
 }
 
-// TestUploadCase tests the download case.
 func TestUploadCase(t *testing.T) {
 	ctx := context.Background()
 	client := newMockedClient(ctx)
@@ -70,8 +66,6 @@ func TestUploadCase(t *testing.T) {
 	}
 }
 
-// TestStartDiscoverServerError ensures that we deal
-// with an error when discovering a server.
 func TestStartDiscoverServerError(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(clientName, clientVersion)
@@ -82,8 +76,6 @@ func TestStartDiscoverServerError(t *testing.T) {
 	}
 }
 
-// TestStartConnectError ensures that we deal
-// with an error when connecting.
 func TestStartConnectError(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(clientName, clientVersion)
@@ -94,7 +86,6 @@ func TestStartConnectError(t *testing.T) {
 	}
 }
 
-// TestIntegrationDownload is an integration test for the download.
 func TestIntegrationDownload(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
@@ -104,39 +95,17 @@ func TestIntegrationDownload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	prev := spec.Measurement{}
 	tot := 0
-	for m := range ch {
+	for range ch {
+		// We already test that measurements follow our expectations
+		// in internal/download/download_test.go.
 		tot++
-		if m.Origin != spec.OriginServer {
-			t.Fatal("Invalid origin")
-		}
-		if m.Direction != spec.DirectionDownload {
-			t.Fatal("Invalid direction")
-		}
-		if m.Elapsed <= prev.Elapsed {
-			t.Fatal("The time is not increasing")
-		}
-		if m.BBRInfo.MaxBandwidth <= 0 {
-			t.Fatal("Unexpected max bandwidth")
-		}
-		if m.BBRInfo.MinRTT <= 0.0 {
-			t.Fatal("Unexpected min RTT")
-		}
-		if m.TCPInfo.RTTVar <= 0.0 {
-			t.Fatal("Unexpected RTT var")
-		}
-		if m.TCPInfo.SmoothedRTT <= 0.0 {
-			t.Fatal("Unexpected smoothed RTT")
-		}
-		prev = m
 	}
 	if tot <= 0 {
 		t.Fatal("Expected at least a measurement")
 	}
 }
 
-// TestIntegrationUpload is an integration test for the upload.
 func TestIntegrationUpload(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
@@ -146,25 +115,11 @@ func TestIntegrationUpload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	prev := spec.Measurement{}
 	tot := 0
-	for m := range ch {
+	for range ch {
 		tot++
-		if m.Origin != spec.OriginClient {
-			t.Fatal("Invalid origin")
-		}
-		if m.Direction != spec.DirectionUpload {
-			t.Fatal("Invalid direction")
-		}
-		if m.Elapsed <= prev.Elapsed {
-			t.Fatal("The time is not increasing")
-		}
-		// Note: it can stay constant when we're servicing
-		// a TCP timeout longer than the update interval
-		if m.AppInfo.NumBytes < prev.AppInfo.NumBytes {
-			t.Fatal("Num bytes is decreasing")
-		}
-		prev = m
+		// We already test that measurements follow our expectations
+		// in internal/upload/upload_test.go.
 	}
 	if tot <= 0 {
 		t.Fatal("Expected at least a measurement")

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -2,11 +2,29 @@
 // https://github.com/m-lab/ndt-server/blob/master/spec/ndt7-protocol.md
 package spec
 
-// OriginKind indicates the origin of a measurement.
-type OriginKind string
+import (
+	"github.com/m-lab/ndt-server/ndt7/model"
+)
 
-// DirectionKind indicates the direction of a measurement.
-type DirectionKind string
+type (
+	// AppInfo contains an application level measurement.
+	AppInfo model.AppInfo
+
+	// BBRInfo contains a BBR measurement.
+	BBRInfo model.BBRInfo
+
+	// ConnectionInfo contains info on this connection.
+	ConnectionInfo model.ConnectionInfo
+
+	// OriginKind indicates the origin of a measurement.
+	OriginKind string
+
+	// TestKind indicates the direction of a measurement.
+	TestKind string
+
+	// TCPInfo contains a TCP_INFO measurement.
+	TCPInfo model.TCPInfo
+)
 
 const (
 	// OriginClient indicates that the measurement origin is the client.
@@ -15,60 +33,31 @@ const (
 	// OriginServer indicates that the measurement origin is the server.
 	OriginServer = OriginKind("server")
 
-	// DirectionDownload indicates that this is a download.
-	DirectionDownload = DirectionKind("download")
+	// TestDownload indicates that this is a download.
+	TestDownload = TestKind("download")
 
-	// DirectionUpload indicates that this is a upload.
-	DirectionUpload = DirectionKind("upload")
+	// TestUpload indicates that this is an upload.
+	TestUpload = TestKind("upload")
 )
-
-// AppInfo contains an application level measurement. This message is
-// consistent with v0.7.0 of the ndt7 spec.
-type AppInfo struct {
-	// NumBytes is the number of bytes transferred so far.
-	NumBytes int64 `json:"num_bytes"`
-}
-
-// The TCPInfo struct contains information measured using TCP_INFO. This
-// message is consistent with v0.7.0 of the ndt7 spec.
-type TCPInfo struct {
-	// SmoothedRTT is the smoothed RTT in milliseconds.
-	SmoothedRTT float64 `json:"smoothed_rtt"`
-
-	// RTTVar is the RTT variance in milliseconds.
-	RTTVar float64 `json:"rtt_var"`
-}
-
-// The BBRInfo struct contains information measured using BBR. This
-// message is consistent with v0.7.0 of the ndt7 spec.
-type BBRInfo struct {
-	// MaxBandwidth is the max bandwidth measured by BBR in bits per second.
-	MaxBandwidth int64 `json:"max_bandwidth"`
-
-	// MinRTT is the min RTT measured by BBR in milliseconds.
-	MinRTT float64 `json:"min_rtt"`
-}
 
 // The Measurement struct contains measurement results. This message is
 // an extension of the one inside of v0.7.0 of the ndt7 spec.
 type Measurement struct {
 	// AppInfo contains application level measurements.
-	AppInfo AppInfo `json:"app_info"`
+	AppInfo *AppInfo `json:",omitempty"`
 
 	// BBRInfo is the data measured using TCP BBR instrumentation.
-	BBRInfo BBRInfo `json:"bbr_info"`
+	BBRInfo *BBRInfo `json:",omitempty"`
 
-	// Direction indicates the measurement direction. This field is
-	// an extension with respect to the spec.
-	Direction DirectionKind `json:"direction"`
+	// ConnectionInfo contains info on the connection.
+	ConnectionInfo *ConnectionInfo `json:",omitempty"`
 
-	// Elapsed is the number of seconds elapsed since the beginning.
-	Elapsed float64 `json:"elapsed"`
+	// Origin indicates who performed this measurement.
+	Origin OriginKind `json:",omitempty"`
 
-	// Origin is either OriginClient or OriginServer. This file is
-	// an extension with respect to the spec.
-	Origin OriginKind `json:"origin"`
+	// Test contains the test name.
+	Test TestKind `json:",omitempty"`
 
 	// TCPInfo contains metrics measured using TCP_INFO instrumentation.
-	TCPInfo TCPInfo `json:"tcp_info"`
+	TCPInfo *TCPInfo `json:",omitempty"`
 }


### PR DESCRIPTION
This mainly boils down to updating the names, making sure we
use application level data for interactive printing.

I've reused m-lab/ndt-server data model, for simplicity.

Also, I didn't know I was not required to document testing
functions when I wrote this code. Now I know, so it is
more simple to not have all these comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/29)
<!-- Reviewable:end -->
