### PR TITLE
ndt7-client: optionally use OpenSSL for TLS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.12.x
+- 1.13.x
 dist: xenial
 
 before_script:

--- a/cmd/ndt7-client/initialize_golang.go
+++ b/cmd/ndt7-client/initialize_golang.go
@@ -10,11 +10,10 @@ import (
 
 // initialize initializes |clnt| to use golang's standard library
 // for doing TLS, which is obviously nice and clean.
-func initialize(clnt *ndt7.Client) error {
+func initialize(clnt *ndt7.Client) {
 	clnt.Scheme = flagScheme.Value
 	clnt.Dialer.TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: *flagNoVerify,
 	}
 	clnt.FQDN = *flagHostname
-	return nil
 }

--- a/cmd/ndt7-client/initialize_golang.go
+++ b/cmd/ndt7-client/initialize_golang.go
@@ -1,0 +1,20 @@
+// +build !ndt7openssl
+
+package main
+
+import (
+	"crypto/tls"
+
+	"github.com/m-lab/ndt7-client-go"
+)
+
+// initialize initializes |clnt| to use golang's standard library
+// for doing TLS, which is obviously nice and clean.
+func initialize(clnt *ndt7.Client) error {
+	clnt.Scheme = flagScheme.Value
+	clnt.Dialer.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: *flagNoVerify,
+	}
+	clnt.FQDN = *flagHostname
+	return nil
+}

--- a/cmd/ndt7-client/initialize_openssl.go
+++ b/cmd/ndt7-client/initialize_openssl.go
@@ -10,7 +10,6 @@ import (
 // initialize initializes |clnt| for using OpenSSL. Because this is a
 // rather non standard config, this is also not super clean.
 func initialize(clnt *ndt7.Client) error {
-	clnt = ndt7.NewClient(clientName, clientVersion)
 	clnt.Scheme = "ws" // even with TLS force websocket to not do TLS
 	dialer, err := openssl.NewDialer()
 	if err != nil {
@@ -23,5 +22,6 @@ func initialize(clnt *ndt7.Client) error {
 		clnt.Dialer.NetDial = dialer.Dial
 		clnt.Dialer.NetDialContext = dialer.DialContext
 	}
+	clnt.FQDN = *flagHostname
 	return nil
 }

--- a/cmd/ndt7-client/initialize_openssl.go
+++ b/cmd/ndt7-client/initialize_openssl.go
@@ -1,0 +1,31 @@
+// +build ndt7openssl
+
+package main
+
+import (
+	"errors"
+
+	"github.com/m-lab/ndt7-client-go"
+	"github.com/m-lab/ndt7-client-go/cmd/ndt7-client/internal/openssl"
+)
+
+// initialize initializes |clnt| for using OpenSSL. Because this is a
+// rather non standard config, this is also not super clean.
+func initialize(clnt *ndt7.Client) error {
+	clnt = ndt7.NewClient(clientName, clientVersion)
+	clnt.Scheme = "ws" // even with TLS force websocket to not do TLS
+	dialer, err := openssl.NewDialer()
+	if err != nil {
+		return err
+	}
+	switch flagScheme.Value {
+	case "ws":
+	case "wss":
+		if *flagNoVerify {
+			return errors.New("openssl: skipping verification not supported")
+		}
+		clnt.Dialer.NetDial = dialer.Dial
+		clnt.Dialer.NetDialContext = dialer.DialContext
+	}
+	return nil
+}

--- a/cmd/ndt7-client/initialize_openssl.go
+++ b/cmd/ndt7-client/initialize_openssl.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"errors"
-
 	"github.com/m-lab/ndt7-client-go"
 	"github.com/m-lab/ndt7-client-go/cmd/ndt7-client/internal/openssl"
 )
@@ -21,9 +19,7 @@ func initialize(clnt *ndt7.Client) error {
 	switch flagScheme.Value {
 	case "ws":
 	case "wss":
-		if *flagNoVerify {
-			return errors.New("openssl: skipping verification not supported")
-		}
+		dialer.InsecureSkipVerify = *flagNoVerify
 		clnt.Dialer.NetDial = dialer.Dial
 		clnt.Dialer.NetDialContext = dialer.DialContext
 	}

--- a/cmd/ndt7-client/initialize_openssl.go
+++ b/cmd/ndt7-client/initialize_openssl.go
@@ -9,12 +9,9 @@ import (
 
 // initialize initializes |clnt| for using OpenSSL. Because this is a
 // rather non standard config, this is also not super clean.
-func initialize(clnt *ndt7.Client) error {
+func initialize(clnt *ndt7.Client) {
 	clnt.Scheme = "ws" // even with TLS force websocket to not do TLS
-	dialer, err := openssl.NewDialer()
-	if err != nil {
-		return err
-	}
+	dialer := openssl.NewDialer()
 	switch flagScheme.Value {
 	case "ws":
 	case "wss":
@@ -23,5 +20,4 @@ func initialize(clnt *ndt7.Client) error {
 		clnt.Dialer.NetDialContext = dialer.DialContext
 	}
 	clnt.FQDN = *flagHostname
-	return nil
 }

--- a/cmd/ndt7-client/internal/openssl/connloop.go
+++ b/cmd/ndt7-client/internal/openssl/connloop.go
@@ -1,0 +1,219 @@
+// +build ndt7openssl
+
+package openssl
+
+import (
+	"os"
+
+	// #include <errno.h>
+	// #include <poll.h>
+	//
+	// #include <openssl/err.h>
+	// #include <openssl/ssl.h>
+	//
+	// #cgo LDFLAGS: -lssl -lcrypto
+	//
+	// /* pollwrapper wraps poll to return the value of errno to the
+	//    caller because CGO cannot access errno. */
+	// static int pollwrapper(int fd, short events, int timeout) {
+	//   struct pollfd pfd;
+	//   pfd.fd = fd;
+	//   pfd.events = events;
+	//   pfd.revents = 0;
+	//   int rv = poll(&pfd, 1, timeout);
+	//   if (rv < 0) {
+	//     return -errno;
+	//   }
+	//   return rv;
+	// }
+	"C"
+)
+import (
+	"context"
+	"errors"
+	"fmt"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// MessageType is the type of a message you send to the connection loop.
+type MessageType int
+
+const (
+	// MessageClose is a request to close the stream.
+	MessageClose = MessageType(iota)
+
+	// MessageRead is a request to read bytes.
+	MessageRead
+
+	// MessageWrite is a request to write bytes.
+	MessageWrite
+)
+
+// Message is a message you send to the connection loop.
+type Message struct {
+	Count    int
+	Data     []byte
+	Deadline time.Time
+	Done     chan interface{}
+	Error    error
+	Type     MessageType
+}
+
+// NewMessage creates a new empty message.
+func NewMessage() *Message {
+	return &Message{
+		Done: make(chan interface{}, 1),
+	}
+}
+
+// RunConnLoop runs the connection loop. Takes ownership of the |fp| and |ssl| args.
+func RunConnLoop(fp *os.File, ssl *C.struct_ssl_st, inch <-chan *Message) {
+	for msg := range inch {
+		switch msg.Type {
+		case MessageClose:
+			// In OpenSSL 1.1+, SSL_set_fd does not take ownership of the
+			// file descriptor hence here we aren't closing twice
+			msg.Error = fp.Close()
+			C.SSL_free(ssl)
+			msg.Done <- true
+			return
+		case MessageRead:
+			msg.Count, msg.Error = read(ssl, msg.Data, msg.Deadline)
+			msg.Done <- true
+		case MessageWrite:
+			msg.Count, msg.Error = write(ssl, msg.Data, msg.Deadline)
+			msg.Done <- true
+		}
+	}
+}
+
+func read(
+	ssl *C.struct_ssl_st,
+	data []byte,
+	deadline time.Time,
+) (int, error) {
+	return readwrite(ssl, data, deadline, doread)
+}
+
+func doread(
+	ssl *C.struct_ssl_st,
+	data []byte,
+) C.int {
+	return C.SSL_read(ssl, unsafe.Pointer(&data[0]), C.int(len(data)))
+}
+
+func write(
+	ssl *C.struct_ssl_st,
+	data []byte,
+	deadline time.Time,
+) (int, error) {
+	total := len(data)
+	for len(data) > 0 {
+		count, err := writeonce(ssl, data, deadline)
+		if err != nil {
+			return 0, err
+		}
+		data = data[count:]
+	}
+	return total, nil
+}
+
+func writeonce(
+	ssl *C.struct_ssl_st,
+	data []byte,
+	deadline time.Time,
+) (int, error) {
+	return readwrite(ssl, data, deadline, dowrite)
+}
+
+func dowrite(
+	ssl *C.struct_ssl_st,
+	data []byte,
+) C.int {
+	return C.SSL_write(ssl, unsafe.Pointer(&data[0]), C.int(len(data)))
+}
+
+func readwrite(
+	ssl *C.struct_ssl_st,
+	data []byte,
+	deadline time.Time,
+	fn func(*C.struct_ssl_st, []byte) C.int,
+) (int, error) {
+	for {
+		var retval C.int
+		if retval = fn(ssl, data); retval > 0 {
+			return int(retval), nil
+		}
+		switch errcode := C.SSL_get_error(ssl, retval); errcode {
+		case C.SSL_ERROR_WANT_READ:
+			if err := poll(ssl, C.POLLIN, deadline); err != nil {
+				return 0, err
+			}
+		case C.SSL_ERROR_WANT_WRITE:
+			if err := poll(ssl, C.POLLOUT, deadline); err != nil {
+				return 0, err
+			}
+		default:
+			return 0, errcodeToErr(errcode)
+		}
+	}
+}
+
+func errcodeToErr(errcode C.int) (err error) {
+	switch errcode {
+	case C.SSL_ERROR_NONE:
+		err = errors.New("SSL_ERROR_NONE")
+	case C.SSL_ERROR_ZERO_RETURN:
+		err = errors.New("SSL_ERROR_ZERO_RETURN")
+	case C.SSL_ERROR_WANT_READ:
+		err = errors.New("SSL_ERROR_WANT_READ")
+	case C.SSL_ERROR_WANT_WRITE:
+		err = errors.New("SSL_ERROR_WANT_WRITE")
+	case C.SSL_ERROR_WANT_CONNECT:
+		err = errors.New("SSL_ERROR_WANT_CONNECT")
+	case C.SSL_ERROR_WANT_ACCEPT:
+		err = errors.New("SSL_ERROR_WANT_ACCEPT")
+	case C.SSL_ERROR_WANT_X509_LOOKUP:
+		err = errors.New("SSL_ERROR_WANT_X509_LOOKUP")
+	case C.SSL_ERROR_SYSCALL:
+		err = errors.New("SSL_ERROR_SYSCALL")
+	case C.SSL_ERROR_SSL:
+		err = errors.New("SSL_ERROR_SSL")
+	default:
+		err = errors.New("SSL_ERROR_UNKNOWN")
+	}
+	for {
+		opensslcode := C.ERR_get_error()
+		if opensslcode == 0 {
+			break
+		}
+		reason := C.GoString(C.ERR_reason_error_string(opensslcode))
+		err = fmt.Errorf("%s: %w", reason, err)
+	}
+	return err
+}
+
+func poll(ssl *C.struct_ssl_st, flags C.short, deadline time.Time) error {
+	fd := C.SSL_get_fd(ssl)
+	for {
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			return context.DeadlineExceeded
+		}
+		var timeout time.Duration = -1
+		if !deadline.IsZero() {
+			timeout = deadline.Sub(time.Now()) * time.Millisecond
+		}
+		if timeout > C.INT_MAX {
+			timeout = C.INT_MAX
+		}
+		retval := C.pollwrapper(fd, flags, C.int(timeout))
+		if retval > 0 {
+			return nil
+		}
+		if retval < 0 && -retval != C.EINTR {
+			return syscall.Errno(-retval)
+		}
+	}
+}

--- a/cmd/ndt7-client/internal/openssl/openssl.go
+++ b/cmd/ndt7-client/internal/openssl/openssl.go
@@ -1,0 +1,298 @@
+// +build ndt7openssl
+
+// Package openssl contains an OpenSSL 1.1+ dialer.
+package openssl
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+
+	// #include <poll.h>
+	//
+	// #include <errno.h>
+	// #include <limits.h>
+	// #include <stdint.h>
+	// #include <stdlib.h>
+	// #include <string.h>
+	//
+	// #include <openssl/err.h>
+	// #include <openssl/ssl.h>
+	//
+	// #cgo LDFLAGS: -lssl -lcrypto
+	//
+	// static int pollwrapper(int fd, short events, int timeout) {
+	//   struct pollfd pfd;
+	//   pfd.fd = fd;
+	//   pfd.events = events;
+	//   pfd.revents = 0;
+	//   int rv = poll(&pfd, 1, timeout);
+	//   if (rv < 0) {
+	//     return -errno;
+	//   }
+	//   return rv;
+	// }
+	"C"
+)
+import "fmt"
+
+// Dialer dials connections using OpenSSL.
+type Dialer struct {
+	CABundlePath string
+	Dialer       *net.Dialer
+}
+
+// ErrCannotGuessCABundlePath is returned when we cannot guess the path of the
+// CA bundle in the current system.
+var ErrCannotGuessCABundlePath = errors.New("openssl: cannot guess CA bundle path")
+
+func guessCABundlePath(readFile func(filename string) ([]byte, error)) (string, error) {
+	// This list of CA bundle path locations was copied from
+	// Measurement Kit m4 directory.
+	candidates := []string{
+		"/etc/pki/tls/certs/ca-bundle.crt",
+		"/etc/ssl/cert.pem",
+		"/etc/ssl/certs/ca-certificates.crt",
+		"/usr/local/etc/openssl/cert.pem",
+		"/usr/local/share/certs/ca-root.crt",
+		"/usr/share/ssl/certs/ca-bundle.crt",
+	}
+	for _, name := range candidates {
+		if _, err := readFile(name); err == nil {
+			return name, nil
+		}
+	}
+	return "", ErrCannotGuessCABundlePath
+}
+
+// NewDialer creates a new dialer. It may fail if we cannot guess the
+// proper CA bundle path for this system.
+func NewDialer() (*Dialer, error) {
+	caBundlePath, err := guessCABundlePath(ioutil.ReadFile)
+	if err != nil {
+		return nil, err
+	}
+	return &Dialer{
+		CABundlePath: caBundlePath,
+		Dialer:       new(net.Dialer),
+	}, nil
+}
+
+// Dial dials an OpenSSL network connection.
+func (d *Dialer) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+// DialContext dials an OpenSSL network connection using a context.
+func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	if network != "tcp" {
+		return nil, errors.New("openssl: only tcp is supported")
+	}
+	conn, err := d.Dialer.DialContext(ctx, network, address)
+	if err != nil {
+		return nil, err
+	}
+	tcpconn := conn.(*net.TCPConn) // don't see why this could fail
+	return d.newconn(tcpconn)
+}
+
+func (d *Dialer) newconn(conn *net.TCPConn) (net.Conn, error) {
+	localAddr := conn.LocalAddr()
+	remoteAddr := conn.RemoteAddr()
+	fp, err := conn.File()
+	conn.Close() // fp contains a cloned socket so we can close conn
+	if err != nil {
+		return nil, err
+	}
+	handle, err := d.newhandle(fp.Fd())
+	if err != nil {
+		fp.Close()
+		return nil, err
+	}
+	return &opensslconn{
+		filep:      fp,
+		handle:     handle,
+		localAddr:  localAddr,
+		remoteAddr: remoteAddr,
+	}, nil
+}
+
+func (d *Dialer) newhandle(fd uintptr) (*C.struct_ssl_st, error) {
+	method := C.TLS_client_method()
+	if method == nil {
+		return nil, errors.New("TLS_method failed")
+	}
+	ctx := C.SSL_CTX_new(method)
+	if ctx == nil {
+		return nil, errors.New("SSL_CTX_new failed")
+	}
+	defer C.SSL_CTX_free(ctx) // note that it's reference counted
+	caBundlePath := C.CString(d.CABundlePath)
+	defer C.free(unsafe.Pointer(caBundlePath))
+	retval := C.SSL_CTX_load_verify_locations(ctx, caBundlePath, nil)
+	if retval != 1 {
+		return nil, errors.New("SSL_CTX_load_verify_locations failed")
+	}
+	ssl := C.SSL_new(ctx)
+	if ssl == nil {
+		return nil, errors.New("SSL_CTX_new failed")
+	}
+	if C.SSL_set_fd(ssl, C.int(fd)) != 1 {
+		C.SSL_free(ssl)
+		return nil, errors.New("SSL_set_fd failed")
+	}
+	C.SSL_set_connect_state(ssl)
+	return ssl, nil
+}
+
+type opensslconn struct {
+	filep      *os.File
+	handle     *C.struct_ssl_st
+	localAddr  net.Addr
+	mu         sync.Mutex
+	remoteAddr net.Addr
+	rdeadline  time.Time
+	wdeadline  time.Time
+}
+
+func (c *opensslconn) Read(b []byte) (n int, err error) {
+	return c.readwrite(func() C.int {
+		return C.SSL_read(c.handle, unsafe.Pointer(&b[0]), C.int(len(b)))
+	})
+}
+
+func (c *opensslconn) Write(b []byte) (int, error) {
+	return c.readwrite(func() C.int {
+		return C.SSL_write(c.handle, unsafe.Pointer(&b[0]), C.int(len(b)))
+	})
+}
+
+func (c *opensslconn) Close() error {
+	// In OpenSSL 1.1+, SSL_set_fd does not take ownership of the
+	// file descriptor hence here we aren't closing twice
+	C.SSL_free(c.handle)
+	return c.filep.Close()
+}
+
+func (c *opensslconn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+
+func (c *opensslconn) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}
+
+func (c *opensslconn) SetDeadline(t time.Time) error {
+	c.SetReadDeadline(t)
+	c.SetWriteDeadline(t)
+	return nil
+}
+
+func (c *opensslconn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rdeadline = t
+	return nil
+}
+
+func (c *opensslconn) SetWriteDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.wdeadline = t
+	return nil
+}
+
+func (c *opensslconn) readwrite(fn func() C.int) (int, error) {
+	for {
+		var (
+			errcode   C.int
+			rdeadline time.Time
+			retval    C.int
+			wdeadline time.Time
+		)
+		// OpenSSL is quite not thread safe
+		c.mu.Lock()
+		rdeadline, wdeadline = c.rdeadline, c.wdeadline
+		if retval = fn(); retval <= 0 {
+			errcode = C.SSL_get_error(c.handle, retval)
+		}
+		c.mu.Unlock()
+		if retval > 0 {
+			return int(retval), nil
+		}
+		switch errcode {
+		case C.SSL_ERROR_WANT_READ:
+			if err := c.poll(C.POLLIN, rdeadline); err != nil {
+				return 0, err
+			}
+		case C.SSL_ERROR_WANT_WRITE:
+			if err := c.poll(C.POLLOUT, wdeadline); err != nil {
+				return 0, err
+			}
+		default:
+			return 0, c.errcodeToErr(errcode)
+		}
+	}
+}
+
+func (c *opensslconn) errcodeToErr(errcode C.int) (err error) {
+	switch errcode {
+	case C.SSL_ERROR_NONE:
+		err = errors.New("SSL_ERROR_NONE")
+	case C.SSL_ERROR_ZERO_RETURN:
+		err = errors.New("SSL_ERROR_ZERO_RETURN")
+	case C.SSL_ERROR_WANT_READ:
+		err = errors.New("SSL_ERROR_WANT_READ")
+	case C.SSL_ERROR_WANT_WRITE:
+		err = errors.New("SSL_ERROR_WANT_WRITE")
+	case C.SSL_ERROR_WANT_CONNECT:
+		err = errors.New("SSL_ERROR_WANT_CONNECT")
+	case C.SSL_ERROR_WANT_ACCEPT:
+		err = errors.New("SSL_ERROR_WANT_ACCEPT")
+	case C.SSL_ERROR_WANT_X509_LOOKUP:
+		err = errors.New("SSL_ERROR_WANT_X509_LOOKUP")
+	case C.SSL_ERROR_SYSCALL:
+		err = errors.New("SSL_ERROR_SYSCALL")
+	case C.SSL_ERROR_SSL:
+		err = errors.New("SSL_ERROR_SSL")
+	default:
+		err = errors.New("SSL_ERROR_UNKNOWN")
+	}
+	for {
+		opensslcode := C.ERR_get_error()
+		if opensslcode == 0 {
+			break
+		}
+		reason := C.GoString(C.ERR_reason_error_string(opensslcode))
+		err = fmt.Errorf("%s: %w", reason, err)
+	}
+	return err
+}
+
+func (c *opensslconn) poll(flags C.short, deadline time.Time) error {
+	for {
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			return context.DeadlineExceeded
+		}
+		var timeout time.Duration = -1
+		if !deadline.IsZero() {
+			timeout = deadline.Sub(time.Now()) * time.Millisecond
+		}
+		if timeout > C.INT_MAX {
+			timeout = C.INT_MAX
+		}
+		retval := C.pollwrapper(C.int(c.filep.Fd()), flags, C.int(timeout))
+		if retval > 0 {
+			return nil
+		}
+		if retval < 0 && -retval != C.EINTR {
+			return syscall.Errno(-retval)
+		}
+	}
+}

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -75,12 +75,12 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"flag"
 	"os"
 	"time"
 
 	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/ndt7-client-go"
 	"github.com/m-lab/ndt7-client-go/cmd/ndt7-client/internal/emitter"
 	"github.com/m-lab/ndt7-client-go/spec"
@@ -178,11 +178,8 @@ func main() {
 	defer cancel()
 	var r runner
 	r.client = ndt7.NewClient(clientName, clientVersion)
-	r.client.Scheme = flagScheme.Value
-	r.client.Dialer.TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: *flagNoVerify,
-	}
-	r.client.FQDN = *flagHostname
+	err := initialize(r.client)
+	rtx.Must(err, "cannot initialize the ndt7 client")
 	if *flagBatch {
 		r.emitter = emitter.NewBatch()
 	} else {

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -80,7 +80,6 @@ import (
 	"time"
 
 	"github.com/m-lab/go/flagx"
-	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/ndt7-client-go"
 	"github.com/m-lab/ndt7-client-go/cmd/ndt7-client/internal/emitter"
 	"github.com/m-lab/ndt7-client-go/spec"
@@ -178,8 +177,7 @@ func main() {
 	defer cancel()
 	var r runner
 	r.client = ndt7.NewClient(clientName, clientVersion)
-	err := initialize(r.client)
-	rtx.Must(err, "cannot initialize the ndt7 client")
+	initialize(r.client)
 	if *flagBatch {
 		r.emitter = emitter.NewBatch()
 	} else {


### PR DESCRIPTION
My objective here is to being able to build `ndt7-client` using
OpenSSL as the TLS engine, which helps a use case that @m-lab has
when running ndt7 with armv7 devices.

I have not touched any public API. This functionality is disabled
by default. The optional `-tags ndt7openssl` command line flag allows
one to compile the client to use OpenSSL. (Further flags such as
`CGO_CFLAGS` and `CGO_LDFLAGS` may be your friends.)

At this stage, I believe we don't want to expose this functionality
to users of this Go library. I consider this being a hack to avoid
the performance issues Go has with armv7.

The idea here is basically that we will use this code to run more
tests and then, if this WAIs, decide what we'll do next.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/33)
<!-- Reviewable:end -->
