### PR TITLE
Only use NewJSON

### DIFF
--- a/cmd/ndt7-client/internal/emitter/json.go
+++ b/cmd/ndt7-client/internal/emitter/json.go
@@ -3,7 +3,6 @@ package emitter
 import (
 	"encoding/json"
 	"io"
-	"os"
 
 	"github.com/m-lab/ndt7-client-go/spec"
 )
@@ -15,14 +14,7 @@ type jsonEmitter struct {
 }
 
 // NewJSON creates a new JSON emitter
-func NewJSON() Emitter {
-	return jsonEmitter{
-		Writer: os.Stdout,
-	}
-}
-
-// NewJSONWithWriter create a new JSON emitter with a custom Writer.
-func NewJSONWithWriter(w io.Writer) Emitter {
+func NewJSON(w io.Writer) Emitter {
 	return jsonEmitter{
 		Writer: w,
 	}

--- a/cmd/ndt7-client/internal/emitter/json_test.go
+++ b/cmd/ndt7-client/internal/emitter/json_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestJSONOnStarting(t *testing.T) {
 	sw := &mocks.SavingWriter{}
-	j := NewJSONWithWriter(sw)
+	j := NewJSON(sw)
 	err := j.OnStarting("download")
 	if err != nil {
 		t.Fatal(err)
@@ -39,7 +39,7 @@ func TestJSONOnStarting(t *testing.T) {
 }
 
 func TestJSONOnStartingFailure(t *testing.T) {
-	j := NewJSONWithWriter(&mocks.FailingWriter{})
+	j := NewJSON(&mocks.FailingWriter{})
 	err := j.OnStarting("download")
 	if err != mocks.ErrMocked {
 		t.Fatal("Not the error we expected")
@@ -48,7 +48,7 @@ func TestJSONOnStartingFailure(t *testing.T) {
 
 func TestJSONOnError(t *testing.T) {
 	sw := &mocks.SavingWriter{}
-	j := NewJSONWithWriter(sw)
+	j := NewJSON(sw)
 	err := j.OnError("download", errors.New("mocked error"))
 	if err != nil {
 		t.Fatal(err)
@@ -79,7 +79,7 @@ func TestJSONOnError(t *testing.T) {
 }
 
 func TestJSONOnErrorFailure(t *testing.T) {
-	j := NewJSONWithWriter(&mocks.FailingWriter{})
+	j := NewJSON(&mocks.FailingWriter{})
 	err := j.OnError("download", errors.New("some error"))
 	if err != mocks.ErrMocked {
 		t.Fatal("Not the error we expected")
@@ -88,7 +88,7 @@ func TestJSONOnErrorFailure(t *testing.T) {
 
 func TestJSONOnConnected(t *testing.T) {
 	sw := &mocks.SavingWriter{}
-	j := NewJSONWithWriter(sw)
+	j := NewJSON(sw)
 	err := j.OnConnected("download", "FQDN")
 	if err != nil {
 		t.Fatal(err)
@@ -119,7 +119,7 @@ func TestJSONOnConnected(t *testing.T) {
 }
 
 func TestJSONOnConnectedFailure(t *testing.T) {
-	j := NewJSONWithWriter(&mocks.FailingWriter{})
+	j := NewJSON(&mocks.FailingWriter{})
 	err := j.OnConnected("download", "FQDN")
 	if err != mocks.ErrMocked {
 		t.Fatal("Not the error we expected")
@@ -128,7 +128,7 @@ func TestJSONOnConnectedFailure(t *testing.T) {
 
 func TestJSONOnDownloadEvent(t *testing.T) {
 	sw := &mocks.SavingWriter{}
-	j := NewJSONWithWriter(sw)
+	j := NewJSON(sw)
 	err := j.OnDownloadEvent(&spec.Measurement{
 		AppInfo: &spec.AppInfo{
 			ElapsedTime: 7100000,
@@ -176,7 +176,7 @@ func TestJSONOnDownloadEvent(t *testing.T) {
 }
 
 func TestJSONOnDownloadEventFailure(t *testing.T) {
-	j := NewJSONWithWriter(&mocks.FailingWriter{})
+	j := NewJSON(&mocks.FailingWriter{})
 	err := j.OnDownloadEvent(&spec.Measurement{})
 	if err != mocks.ErrMocked {
 		t.Fatal("Not the error we expected")
@@ -185,7 +185,7 @@ func TestJSONOnDownloadEventFailure(t *testing.T) {
 
 func TestJSONOnUploadEvent(t *testing.T) {
 	sw := &mocks.SavingWriter{}
-	j := NewJSONWithWriter(sw)
+	j := NewJSON(sw)
 	err := j.OnUploadEvent(&spec.Measurement{
 		AppInfo: &spec.AppInfo{
 			ElapsedTime: 3000000,
@@ -233,7 +233,7 @@ func TestJSONOnUploadEvent(t *testing.T) {
 }
 
 func TestJSONOnUploadEventFailure(t *testing.T) {
-	j := NewJSONWithWriter(&mocks.FailingWriter{})
+	j := NewJSON(&mocks.FailingWriter{})
 	err := j.OnUploadEvent(&spec.Measurement{})
 	if err != mocks.ErrMocked {
 		t.Fatal("Not the error we expected")
@@ -242,7 +242,7 @@ func TestJSONOnUploadEventFailure(t *testing.T) {
 
 func TestJSONOnComplete(t *testing.T) {
 	sw := &mocks.SavingWriter{}
-	j := NewJSONWithWriter(sw)
+	j := NewJSON(sw)
 	err := j.OnComplete("download")
 	if err != nil {
 		t.Fatal(err)
@@ -269,23 +269,16 @@ func TestJSONOnComplete(t *testing.T) {
 }
 
 func TestJSONOnCompleteFailure(t *testing.T) {
-	j := NewJSONWithWriter(&mocks.FailingWriter{})
+	j := NewJSON(&mocks.FailingWriter{})
 	err := j.OnComplete("download")
 	if err != mocks.ErrMocked {
 		t.Fatal("Not the error we expected")
 	}
 }
 
-func TestNewJSONConstructor(t *testing.T) {
-	j := NewJSON()
-	if j == nil {
+func TestNewJSON(t *testing.T) {
+	if NewJSON(&mocks.SavingWriter{}) == nil {
 		t.Fatal("NewJSON did not return an Emitter")
-	}
-}
-
-func TestNewJSONWithWriter(t *testing.T) {
-	if NewJSONWithWriter(&mocks.SavingWriter{}) == nil {
-		t.Fatal("NewJSONWithWriter did not return an Emitter")
 	}
 }
 
@@ -307,7 +300,7 @@ func TestEmitInterfaceFailure(t *testing.T) {
 func TestJSONOnSummary(t *testing.T) {
 	summary := &Summary{}
 	sw := &mocks.SavingWriter{}
-	j := NewJSONWithWriter(sw)
+	j := NewJSON(sw)
 	err := j.OnSummary(summary)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -255,7 +255,7 @@ func main() {
 
 	// If -batch, force -format=json.
 	if *flagBatch || flagFormat.Value == "json" {
-		e = emitter.NewJSON()
+		e = emitter.NewJSON(os.Stdout)
 	} else {
 		e = emitter.NewHumanReadable()
 	}

--- a/cmd/ndt7-client/main_test.go
+++ b/cmd/ndt7-client/main_test.go
@@ -222,7 +222,7 @@ func TestBatchEmitterEventsOrderNormal(t *testing.T) {
 	writer := &mocks.SavingWriter{}
 	runner := runner{
 		client:  ndt7.NewClient(clientName, clientVersion),
-		emitter: emitter.NewJSONWithWriter(writer),
+		emitter: emitter.NewJSON(writer),
 	}
 	code := runner.runTest(
 		context.Background(),
@@ -275,7 +275,7 @@ func TestBatchEmitterEventsOrderFailure(t *testing.T) {
 	writer := &mocks.SavingWriter{}
 	runner := runner{
 		client:  ndt7.NewClient(clientName, clientVersion),
-		emitter: emitter.NewJSONWithWriter(writer),
+		emitter: emitter.NewJSON(writer),
 	}
 	runner.client.MLabNSClient.BaseURL = "\t" // URL parser error
 	code := runner.runTest(


### PR DESCRIPTION
I miscommunicated, so now I pay the price.

This eliminates `NewJSONWithWriter` in favor of `NewJSON`.  `main()` can pass in `os.Stdout` just fine, and this change simplifies both testing and naming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/41)
<!-- Reviewable:end -->
