### PR TITLE
Add ServerIP and DownloadUUID to the JSON summary

### DIFF
--- a/cmd/ndt7-client/internal/emitter/humanreadable.go
+++ b/cmd/ndt7-client/internal/emitter/humanreadable.go
@@ -86,8 +86,8 @@ func (h HumanReadable) OnSummary(s *Summary) error {
 %15s: %7.2f %s
 `
 	_, err := fmt.Fprintf(h.out, summaryFormat,
-		"Server", s.Server,
-		"Client", s.Client,
+		"Server", s.ServerFQDN,
+		"Client", s.ClientIP,
 		"Latency", s.RTT.Value, s.RTT.Unit,
 		"Download", s.Download.Value, s.Upload.Unit,
 		"Upload", s.Upload.Value, s.Upload.Unit,

--- a/cmd/ndt7-client/internal/emitter/humanreadable_test.go
+++ b/cmd/ndt7-client/internal/emitter/humanreadable_test.go
@@ -228,8 +228,8 @@ func TestHumanReadableOnSummary(t *testing.T) {
  Retransmission:    1.00 %
 `
 	summary := &Summary{
-		Client: "test",
-		Server: "test",
+		ClientIP:   "test",
+		ServerFQDN: "test",
 		Download: ValueUnitPair{
 			Value: 100.0,
 			Unit:  "Mbit/s",

--- a/cmd/ndt7-client/internal/emitter/json_test.go
+++ b/cmd/ndt7-client/internal/emitter/json_test.go
@@ -314,8 +314,8 @@ func TestJSONOnSummary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if output.Client != summary.Client ||
-		output.Server != summary.Server ||
+	if output.ClientIP != summary.ClientIP ||
+		output.ServerFQDN != summary.ServerFQDN ||
 		output.Download != summary.Download ||
 		output.Upload != summary.Upload ||
 		output.DownloadRetrans != summary.DownloadRetrans ||

--- a/cmd/ndt7-client/internal/emitter/json_test.go
+++ b/cmd/ndt7-client/internal/emitter/json_test.go
@@ -316,6 +316,8 @@ func TestJSONOnSummary(t *testing.T) {
 	}
 	if output.ClientIP != summary.ClientIP ||
 		output.ServerFQDN != summary.ServerFQDN ||
+		output.ServerIP != summary.ServerIP ||
+		output.DownloadUUID != summary.DownloadUUID ||
 		output.Download != summary.Download ||
 		output.Upload != summary.Upload ||
 		output.DownloadRetrans != summary.DownloadRetrans ||

--- a/cmd/ndt7-client/internal/emitter/summary.go
+++ b/cmd/ndt7-client/internal/emitter/summary.go
@@ -9,11 +9,18 @@ type ValueUnitPair struct {
 // Summary is a struct containing the values displayed to the user at
 // the end of an ndt7 test.
 type Summary struct {
-	// Server is the FQDN of the server used for this test.
-	Server string
+	// ServerFQDN is the FQDN of the server used for this test.
+	ServerFQDN string
 
-	// Client is the IP address of the client.
-	Client string
+	// ServerIP is the (v4 or v6) IP address of the server.
+	ServerIP string
+
+	// ClientIP is the (v4 or v6) IP address of the client.
+	ClientIP string
+
+	// DownloadUUID is the UUID of the download test.
+	// TODO: add UploadUUID after we start processing counterflow messages.
+	DownloadUUID string
 
 	// Download is the download speed, in Mbit/s. This is measured at the
 	// receiver.
@@ -34,6 +41,6 @@ type Summary struct {
 // NewSummary returns a new Summary struct for a given FQDN.
 func NewSummary(FQDN string) *Summary {
 	return &Summary{
-		Server: FQDN,
+		ServerFQDN: FQDN,
 	}
 }

--- a/cmd/ndt7-client/internal/emitter/summary_test.go
+++ b/cmd/ndt7-client/internal/emitter/summary_test.go
@@ -9,7 +9,7 @@ func TestNewSummary(t *testing.T) {
 	if s == nil {
 		t.Fatal("NewSummary() did not return a Summary")
 	}
-	if s.Server != "test" {
+	if s.ServerFQDN != "test" {
 		t.Fatal("NewSummary(): unexpected Server field")
 	}
 }

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -80,8 +80,8 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
+	"net"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/m-lab/go/flagx"
@@ -192,9 +192,18 @@ func makeSummary(FQDN string, results map[spec.TestKind]*ndt7.LatestMeasurements
 
 	if results[spec.TestDownload] != nil &&
 		results[spec.TestDownload].ConnectionInfo != nil {
-		endpoint := strings.Split(
-			results[spec.TestDownload].ConnectionInfo.Client, ":")
-		s.Client = endpoint[0]
+		// Get UUID, ClientIP and ServerIP from ConnectionInfo.
+		s.DownloadUUID = results[spec.TestDownload].ConnectionInfo.UUID
+
+		clientIP, _, err := net.SplitHostPort(results[spec.TestDownload].ConnectionInfo.Client)
+		if err == nil {
+			s.ClientIP = clientIP
+		}
+
+		serverIP, _, err := net.SplitHostPort(results[spec.TestDownload].ConnectionInfo.Server)
+		if err == nil {
+			s.ServerIP = serverIP
+		}
 	}
 
 	// Download comes from the client-side Measurement during the download

--- a/cmd/ndt7-client/main_test.go
+++ b/cmd/ndt7-client/main_test.go
@@ -352,8 +352,8 @@ func TestMakeSummary(t *testing.T) {
 	}
 
 	expected := &emitter.Summary{
-		Client: "127.0.0.1",
-		Server: "test",
+		ClientIP:   "127.0.0.1",
+		ServerFQDN: "test",
 		Download: emitter.ValueUnitPair{
 			Value: 800.0,
 			Unit:  "Mbit/s",

--- a/cmd/ndt7-client/main_test.go
+++ b/cmd/ndt7-client/main_test.go
@@ -334,8 +334,9 @@ func TestMakeSummary(t *testing.T) {
 				},
 			},
 			ConnectionInfo: &spec.ConnectionInfo{
-				Client: "127.0.0.1",
-				Server: "test",
+				Client: "127.0.0.1:12345",
+				Server: "127.0.0.2:443",
+				UUID:   "test-uuid",
 			},
 			Server: spec.Measurement{
 				TCPInfo: tcpInfo,
@@ -352,8 +353,10 @@ func TestMakeSummary(t *testing.T) {
 	}
 
 	expected := &emitter.Summary{
-		ClientIP:   "127.0.0.1",
-		ServerFQDN: "test",
+		ServerFQDN:   "test",
+		ClientIP:     "127.0.0.1",
+		ServerIP:     "127.0.0.2",
+		DownloadUUID: "test-uuid",
 		Download: emitter.ValueUnitPair{
 			Value: 800.0,
 			Unit:  "Mbit/s",
@@ -373,6 +376,7 @@ func TestMakeSummary(t *testing.T) {
 	}
 
 	generated := makeSummary("test", results)
+
 	if !reflect.DeepEqual(generated, expected) {
 		t.Fatal("makeSummary(): unexpected summary data")
 	}


### PR DESCRIPTION
This PR adds `ServerIP` and `DownloadUUID` to the JSON summary. Also, it renames `Client` to `ClientIP` and `Server` to `ServerFQDN` for clarity. 

Updated output:
```
$ ./ndt7-client --format=json -quiet | jq
{
  "ServerFQDN": "ndt-iupui-mlab1-mil02.measurement-lab.org",
  "ServerIP": "80.239.222.11",
  "ClientIP": "93.188.101.116",
  "DownloadUUID": "ndt-2fc6w_1580337823_0000000000013A15",
  "Download": {
    "Value": 409.2345790836791,
    "Unit": "Mbit/s"
  },
  "Upload": {
    "Value": 52.24895095397535,
    "Unit": "Mbit/s"
  },
  "DownloadRetrans": {
    "Value": 1.8086134159429401,
    "Unit": "%"
  },
  "RTT": {
    "Value": 25.352,
    "Unit": "ms"
  }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/42)
<!-- Reviewable:end -->
