### PR TITLE
Added prometheus exporter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.inferGopath": false
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 FROM golang:alpine as builder
 
 ENV CGO_ENABLED=0
@@ -26,7 +27,7 @@ RUN adduser -D -g '' appuser
 ADD . ${GOPATH}/src/app/
 WORKDIR ${GOPATH}/src/app
 
-RUN go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/mlab_exporter
+RUN go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/mlab_exporter cmd/ndt7-client/main.go
 
 # --------------------------------------------------------------------------------
 
@@ -45,3 +46,5 @@ COPY --from=builder /etc/passwd /etc/passwd
 EXPOSE 9122
 
 ENTRYPOINT [ "/usr/bin/mlab_exporter", "-format", "prometheus" ]
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:alpine as builder
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
+ENV GO111MODULE=on
+
+RUN apk update \
+    && apk add --no-cache git ca-certificates tzdata \
+    && update-ca-certificates
+
+RUN adduser -D -g '' appuser
+
+ADD . ${GOPATH}/src/app/
+WORKDIR ${GOPATH}/src/app
+
+RUN go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/mlab_exporter
+
+# --------------------------------------------------------------------------------
+
+FROM gcr.io/distroless/base
+
+LABEL summary="mlab Speedtest Prometheus exporter" \
+      description="A Prometheus exporter for broadband speedtests using m-lab" \
+      name="wlbr/ndt7-client-go" \
+      url="https://github.com/wlbr/ndt7-client-go" \
+      maintainer="Michael Wolber <mwolber@gmx.de>"
+
+COPY --from=builder /go/bin/mlab_exporter /usr/bin/mlab_exporter
+
+COPY --from=builder /etc/passwd /etc/passwd
+
+EXPOSE 9122
+
+ENTRYPOINT [ "/usr/bin/mlab_exporter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ FROM gcr.io/distroless/base
 
 LABEL summary="mlab Speedtest Prometheus exporter" \
       description="A Prometheus exporter for broadband speedtests using m-lab" \
-      name="wlbr/ndt7-client-go" \
+      name="wlbr/mlab-exporter" \
       url="https://github.com/wlbr/ndt7-client-go" \
       maintainer="Michael Wolber <mwolber@gmx.de>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ COPY --from=builder /etc/passwd /etc/passwd
 
 EXPOSE 9122
 
-ENTRYPOINT [ "/usr/bin/mlab_exporter" ]
+ENTRYPOINT [ "/usr/bin/mlab_exporter", "-format", "prometheus" ]

--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ go get -v github.com/m-lab/ndt7-client-go/cmd/ndt7-client
 
 is equivalent to cloning the repository, running `go get ./cmd/ndt7-client`,
 and then cancelling the repository directory.
+
+
+### Prometheus exporter
+
+If you start the client using the flag `-format=prometheus`, then a http server will be started that runs a speed test evertime the exposed handler on http://localhost/metrics is called. The results will be shown in a format that is readable by [Prometheus](https://prometheus.io), so that you can run the tests freqeuently, automated and collect the results. This can be visualized using [Grafana](https://grafana.com), for example.

--- a/cmd/ndt7-client/internal/emitter/prometheus.go
+++ b/cmd/ndt7-client/internal/emitter/prometheus.go
@@ -1,0 +1,128 @@
+package emitter
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/m-lab/ndt7-client-go/spec"
+)
+
+// PrometheusExporter is a human readable emitter. It emits the events generated
+// by running a ndt7 test as pleasant stdout messages.
+type PrometheusExporter struct {
+	out io.Writer
+}
+
+// NewPrometheusExporter returns a new human readable emitter.
+func NewPrometheusExporter() Emitter {
+	return PrometheusExporter{os.Stdout}
+}
+
+// NewPrometheusExporterWithWriter returns a new human readable emitter using the
+// specified writer.
+func NewPrometheusExporterWithWriter(w io.Writer) Emitter {
+	return PrometheusExporter{w}
+}
+
+// OnStarting handles the start event
+func (h PrometheusExporter) OnStarting(test spec.TestKind) error {
+	// _, err := fmt.Fprintf(h.out, "\rstarting %s", test)
+	// return err
+	return nil
+}
+
+// OnError handles the error event
+func (h PrometheusExporter) OnError(test spec.TestKind, err error) error {
+	_, failure := fmt.Fprintf(h.out, "\r%s failed: %s\n", test, err.Error())
+	return failure
+}
+
+// OnConnected handles the connected event
+func (h PrometheusExporter) OnConnected(test spec.TestKind, fqdn string) error {
+	// _, err := fmt.Fprintf(h.out, "\r%s in progress with %s\n", test, fqdn)
+	// return err
+	return nil
+}
+
+// OnDownloadEvent handles an event emitted by the download test
+func (h PrometheusExporter) OnDownloadEvent(m *spec.Measurement) error {
+	return h.onSpeedEvent(m)
+}
+
+// OnUploadEvent handles an event emitted during the upload test
+func (h PrometheusExporter) OnUploadEvent(m *spec.Measurement) error {
+	return h.onSpeedEvent(m)
+}
+
+func (h PrometheusExporter) onSpeedEvent(m *spec.Measurement) error {
+	// The specification recommends that we show application level
+	// measurements. Let's just do that in interactive mode. To this
+	// end, we ignore any measurement coming from the server.
+	// if m.Origin != spec.OriginClient {
+	// 	return nil
+	// }
+	// if m.AppInfo == nil || m.AppInfo.ElapsedTime <= 0 {
+	// 	return errors.New("Missing m.AppInfo or invalid m.AppInfo.ElapsedTime")
+	// }
+	// elapsed := float64(m.AppInfo.ElapsedTime) / 1e06
+	// v := (8.0 * float64(m.AppInfo.NumBytes)) / elapsed / (1000.0 * 1000.0)
+	// _, err := fmt.Fprintf(h.out, "\rAvg. speed  : %7.1f Mbit/s", v)
+	// return err
+	return nil
+}
+
+// OnComplete handles the complete event
+func (h PrometheusExporter) OnComplete(test spec.TestKind) error {
+	// _, err := fmt.Fprintf(h.out, "\n%s: complete\n", test)
+	// return err
+	return nil
+}
+
+// # HELP m-lab_download Download bandwidth (Mbps).
+// # TYPE m-lab_download gauge
+// m-lab_download 51.77325110921138
+// # HELP m-lab_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which m-lab_exporter was built.
+// # TYPE m-lab_exporter_build_info gauge
+// m-lab_exporter_build_info{branch="",goversion="go1.12.9",revision="",version=""} 1.0
+// # HELP m-lab_ping Latency (ms)
+// # TYPE m-lab_ping gauge
+// m-lab_ping 33.138479
+// # HELP m-lab_upload Upload bandwidth (Mbps).
+// # TYPE m-lab_upload gauge
+// m-lab_upload 21.660442480282065
+
+// OnSummary handles the summary event.
+func (h PrometheusExporter) OnSummary(s *Summary) error {
+	const summaryFormat = `# HELP m-lab_download Download bandwidth (%s).
+# TYPE m-lab_download gauge
+m-lab_download %7.1f
+# HELP m-lab_ping Latency (%s)
+# TYPE m-lab_ping gauge
+m-lab_ping %7.1f
+# HELP m-lab_upload Upload bandwidth (%s).
+# TYPE m-lab_upload gauge
+m-lab_upload %7.1f
+# HELP m-lab_servername server name.
+# TYPE m-lab_servername text
+m-lab_servername %s
+# HELP m-lab_clientip client IP.
+# TYPE m-lab_clientip text
+m-lab_clientip %s`
+
+	_, err := fmt.Fprintf(h.out, summaryFormat,
+		s.Download.Unit,
+		s.Download.Value,
+		s.RTT.Unit,
+		s.RTT.Value,
+		s.Upload.Unit,
+		s.Upload.Value,
+		s.ServerFQDN,
+		s.ClientIP)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/ndt7-client/internal/emitter/prometheus.go
+++ b/cmd/ndt7-client/internal/emitter/prometheus.go
@@ -95,20 +95,20 @@ func (h PrometheusExporter) OnComplete(test spec.TestKind) error {
 // OnSummary handles the summary event.
 func (h PrometheusExporter) OnSummary(s *Summary) error {
 	const summaryFormat = `# HELP m-lab_download Download bandwidth (%s).
-# TYPE m-lab_download gauge
-m-lab_download %7.1f
-# HELP m-lab_ping Latency (%s)
-# TYPE m-lab_ping gauge
-m-lab_ping %7.1f
-# HELP m-lab_upload Upload bandwidth (%s).
-# TYPE m-lab_upload gauge
-m-lab_upload %7.1f
-# HELP m-lab_servername server name.
-# TYPE m-lab_servername text
-m-lab_servername %s
-# HELP m-lab_clientip client IP.
-# TYPE m-lab_clientip text
-m-lab_clientip %s
+# TYPE mlab_download gauge
+mlab_download %7.1f
+# HELP mlab_ping Latency (%s)
+# TYPE mlab_ping gauge
+mlab_ping %7.1f
+# HELP mlab_upload Upload bandwidth (%s).
+# TYPE mlab_upload gauge
+mlab_upload %7.1f
+# HELP mlab_servername server name.
+# TYPE mlab_servername text
+mlab_servername %s
+# HELP mlab_clientip client IP.
+# TYPE mlab_clientip text
+mlab_clientip %s
 `
 
 	_, err := fmt.Fprintf(h.out, summaryFormat,

--- a/cmd/ndt7-client/internal/emitter/prometheus.go
+++ b/cmd/ndt7-client/internal/emitter/prometheus.go
@@ -103,15 +103,6 @@ mlab_ping %7.1f
 # HELP mlab_upload Upload bandwidth (%s).
 # TYPE mlab_upload gauge
 mlab_upload %7.1f
-# HELP mlab_servername server FQDN.
-# TYPE mlab_servername text
-mlab_servername %s
-# HELP mlab_serverip server IP.
-# TYPE mlab_serverip text
-mlab_serverip %s
-# HELP mlab_clientip client IP.
-# TYPE mlab_clientip text
-mlab_clientip %s
 # HELP mlab_rtt RTT (%s)
 # TYPE mlab_rtt gauge
 mlab_rtt %7.1f
@@ -124,9 +115,6 @@ mlab_rtt %7.1f
 		s.RTT.Value,
 		s.Upload.Unit,
 		s.Upload.Value,
-		s.ServerFQDN,
-		s.ServerIP,
-		s.ClientIP,
 		s.RTT.Unit,
 		s.RTT.Value)
 

--- a/cmd/ndt7-client/internal/emitter/prometheus.go
+++ b/cmd/ndt7-client/internal/emitter/prometheus.go
@@ -103,12 +103,18 @@ mlab_ping %7.1f
 # HELP mlab_upload Upload bandwidth (%s).
 # TYPE mlab_upload gauge
 mlab_upload %7.1f
-# HELP mlab_servername server name.
+# HELP mlab_servername server FQDN.
 # TYPE mlab_servername text
 mlab_servername %s
+# HELP mlab_serverip server IP.
+# TYPE mlab_serverip text
+mlab_serverip %s
 # HELP mlab_clientip client IP.
 # TYPE mlab_clientip text
 mlab_clientip %s
+# HELP mlab_rtt RTT (%s)
+# TYPE mlab_rtt gauge
+mlab_rtt %7.1f
 `
 
 	_, err := fmt.Fprintf(h.out, summaryFormat,
@@ -119,7 +125,10 @@ mlab_clientip %s
 		s.Upload.Unit,
 		s.Upload.Value,
 		s.ServerFQDN,
-		s.ClientIP)
+		s.ServerIP,
+		s.ClientIP,
+		s.RTT.Unit,
+		s.RTT.Value)
 
 	if err != nil {
 		return err

--- a/cmd/ndt7-client/internal/emitter/prometheus.go
+++ b/cmd/ndt7-client/internal/emitter/prometheus.go
@@ -108,7 +108,8 @@ m-lab_upload %7.1f
 m-lab_servername %s
 # HELP m-lab_clientip client IP.
 # TYPE m-lab_clientip text
-m-lab_clientip %s`
+m-lab_clientip %s
+`
 
 	_, err := fmt.Fprintf(h.out, summaryFormat,
 		s.Download.Unit,

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -265,7 +265,7 @@ func runWithRetry(ctx context.Context, f func(c context.Context) int) int {
 	for i := 0; result != 0 && i < max; i++ {
 		result = f(ctx)
 		if i > 0 {
-			log.Printf("Retry no %d during %v, error code %d ", i, runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name(), result)
+			log.Printf("Retry #%d during '%v', error code: %d", i, runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name(), result)
 			time.Sleep(1 * time.Second)
 		}
 	}

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -171,7 +171,6 @@ func (r runner) runTest(
 	// Implementation note: we want to always emit the initial and the
 	// final events regardless of how the actual test goes. What's more,
 	// we want the exit code to be nonzero in case of any error.
-	log.Printf("runTest starting")
 	err := r.emitter.OnStarting(test)
 	if err != nil {
 		log.Printf("runTest got error %s:  %s", r.client.ClientName, err)
@@ -183,18 +182,15 @@ func (r runner) runTest(
 		log.Printf("runTest got error in client %s: %s", r.client.ClientName, err)
 		return 1
 	}
-	log.Printf("code %d", code)
 	return code
 }
 
 func (r runner) runDownload(ctx context.Context) int {
-	log.Printf("Starting Download")
 	return r.runTest(ctx, spec.TestDownload, r.client.StartDownload,
 		r.emitter.OnDownloadEvent)
 }
 
 func (r runner) runUpload(ctx context.Context) int {
-	log.Printf("Starting  Upload")
 	return r.runTest(ctx, spec.TestUpload, r.client.StartUpload,
 		r.emitter.OnUploadEvent)
 }
@@ -288,7 +284,7 @@ func prommain() {
 		}
 		s := makeSummary(r.client.FQDN, r.client.Results())
 		r.emitter.OnSummary(s)
-		log.Printf("Speed test finished %0.2f / %0.2f", s.Download.Value, s.Upload.Value)
+		log.Printf("Speed test finished %0.2f / %0.2f at %s", s.Download.Value, s.Upload.Value, s.ServerFQDN)
 	})
 
 	log.Printf("Starting server at %s", *listenAddress)

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -114,7 +114,7 @@ var (
 	flagTimeout  = flag.Duration(
 		"timeout", defaultTimeout, "time after which the test is aborted")
 	flagQuiet     = flag.Bool("quiet", false, "emit summary and errors only")
-	listenAddress = flag.String("listen-address", "localhost:9122", "Address to listen to server prometheus metrics.")
+	listenAddress = flag.String("listen-address", ":9122", "Address to listen to server prometheus metrics.")
 	metricsPath   = flag.String("metrics-path", "/metrics", "Path under which to expose prometheus metrics.")
 )
 

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -261,8 +261,12 @@ func makeSummary(FQDN string, results map[spec.TestKind]*ndt7.LatestMeasurements
 
 var osExit = os.Exit
 
-func prommain(ctx context.Context) {
+func prommain() {
+
 	http.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
+		ctx, cancel := context.WithTimeout(context.Background(), *flagTimeout)
+		defer cancel()
+
 		var r runner
 		r.client = ndt7.NewClient(clientName, clientVersion)
 		r.client.Scheme = flagScheme.Value
@@ -293,12 +297,12 @@ func prommain(ctx context.Context) {
 
 func main() {
 	flag.Parse()
-	ctx, cancel := context.WithTimeout(context.Background(), *flagTimeout)
-	defer cancel()
 
 	if flagFormat.Value == "prometheus" {
-		prommain(ctx)
+		prommain()
 	} else {
+		ctx, cancel := context.WithTimeout(context.Background(), *flagTimeout)
+		defer cancel()
 		var r runner
 		r.client = ndt7.NewClient(clientName, clientVersion)
 		r.client.Scheme = flagScheme.Value

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -297,7 +297,7 @@ func main() {
 			log.Printf("Speed test finished %0.2f / %0.2f", s.Download.Value, s.Upload.Value)
 		})
 		log.Printf("Starting server at %s", *listenAddress)
-		http.ListenAndServe(*listenAddress, nil)
+		log.Print(http.ListenAndServe(*listenAddress, nil))
 	} else {
 		code := r.runDownload(ctx) + r.runUpload(ctx)
 		if code != 0 {

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -252,10 +252,6 @@ func makeSummary(FQDN string, results map[spec.TestKind]*ndt7.LatestMeasurements
 
 var osExit = os.Exit
 
-func prometheusHandler() {
-
-}
-
 func main() {
 	flag.Parse()
 	ctx, cancel := context.WithTimeout(context.Background(), *flagTimeout)
@@ -284,12 +280,12 @@ func main() {
 	r.emitter = e
 
 	if flagFormat.Value == "prometheus" {
-
 		http.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
 			r.emitter = emitter.NewPrometheusExporterWithWriter(w)
 			log.Printf("Got request to %s from %s, starting speed test", req.RequestURI, req.RemoteAddr)
 			code := r.runDownload(ctx) + r.runUpload(ctx)
 			if code != 0 {
+				log.Printf("Got error code %d", code)
 				osExit(code)
 			}
 			s := makeSummary(r.client.FQDN, r.client.Results())

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -146,19 +146,19 @@ func (r runner) doRunTest(
 ) int {
 	ch, err := start(ctx)
 	if err != nil {
-		log.Print("doRunTest start error: %v", err)
+		log.Printf("doRunTest start error: %v", err)
 		r.emitter.OnError(test, err)
 		return 1
 	}
 	err = r.emitter.OnConnected(test, r.client.FQDN)
 	if err != nil {
-		log.Print("doRunTest OnConnected error: %v", err)
+		log.Printf("doRunTest OnConnected error: %v", err)
 		return 1
 	}
 	for ev := range ch {
 		err = emitEvent(&ev)
 		if err != nil {
-			log.Print("doRunTest emitEvent error: %v", err)
+			log.Printf("doRunTest emitEvent error: %v", err)
 			return 1
 		}
 	}
@@ -261,10 +261,10 @@ var osExit = os.Exit
 
 func runWithRetry(ctx context.Context, f func(c context.Context) int) int {
 	result := -1
-	max := 5
+	max := 10
 	for i := 0; result != 0 && i < max; i++ {
 		result = f(ctx)
-		if i > 0 {
+		if i > 0 && result != 0 {
 			log.Printf("Retry #%d during '%v', error code: %d", i, runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name(), result)
 			time.Sleep(1 * time.Second)
 		}

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -285,18 +285,16 @@ func main() {
 
 	if flagFormat.Value == "prometheus" {
 
-		http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
-			log.Printf("Got request to %s from %s", req.RequestURI, req.RemoteAddr)
+		http.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
 			r.emitter = emitter.NewPrometheusExporterWithWriter(w)
+			log.Printf("Got request to %s from %s, starting speed test", req.RequestURI, req.RemoteAddr)
 			code := r.runDownload(ctx) + r.runUpload(ctx)
 			if code != 0 {
 				osExit(code)
 			}
-			log.Printf("Emitter finished, making summary")
 			s := makeSummary(r.client.FQDN, r.client.Results())
-			log.Printf("makeSummary finished %0.2f / %0.2f", s.Download.Value, s.Upload.Value)
 			r.emitter.OnSummary(s)
-			log.Printf("OnSummary finished")
+			log.Printf("Speed test finished %0.2f / %0.2f", s.Download.Value, s.Upload.Value)
 		})
 		log.Printf("Starting server at %s", *listenAddress)
 		http.ListenAndServe(*listenAddress, nil)

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -261,12 +261,12 @@ var osExit = os.Exit
 
 func runWithRetry(ctx context.Context, f func(c context.Context) int) int {
 	result := -1
-	max := 10
+	max := 4
 	for i := 0; result != 0 && i < max; i++ {
 		result = f(ctx)
 		if i > 0 && result != 0 {
 			log.Printf("Retry #%d during '%v', error code: %d", i, runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name(), result)
-			time.Sleep(1 * time.Second)
+			time.Sleep(time.Duration(i*3) * time.Second)
 		}
 	}
 	return result


### PR DESCRIPTION
Added a new emitter to generate the prometheus metrics format.
Added a http server that will be startet when "-format=prometheus" is used on the command line.
Added dockerfile to be able to easily install it as a container.

That way it is possible to run the tests driven by prometheus/grafana frequently to generate stats of your upstream connection. I run it on my docker capable Synology, but any local server would be useable. 


**I case you choose to accept the pull request you would need to adapt the contact information in the Dockerfile.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/45)
<!-- Reviewable:end -->
