### PR TITLE
Rename -hostname to -server

### DIFF
--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -109,7 +109,7 @@ var (
 	flagBatch = flag.Bool("batch", false, "emit JSON events on stdout "+
 		"(DEPRECATED, please use -format=json)")
 	flagNoVerify = flag.Bool("no-verify", false, "skip TLS certificate verification")
-	flagHostname = flag.String("hostname", "", "optional ndt7 server hostname")
+	flagServer   = flag.String("server", "", "optional ndt7 server hostname")
 	flagTimeout  = flag.Duration(
 		"timeout", defaultTimeout, "time after which the test is aborted")
 	flagQuiet = flag.Bool("quiet", false, "emit summary and errors only")
@@ -258,7 +258,7 @@ func main() {
 	r.client.Dialer.TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: *flagNoVerify,
 	}
-	r.client.FQDN = *flagHostname
+	r.client.FQDN = *flagServer
 
 	var e emitter.Emitter
 

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -12,9 +12,9 @@
 // The (DEPRECATED) `-batch` flag is equivalent to `-format json`, and the
 // latter should be used instead.
 //
-// The `-hostname <name>` flag specifies to use the `name` hostname for
-// performing the ndt7 test. The default is to auto-discover a suitable
-// server by using Measurement Lab's locate service.
+// The `-server <name>` (previously `-hostname`) flag specifies to use the
+// `name` hostname for performing the ndt7 test. The default is to
+// auto-discover a suitable server by using Measurement Lab's locate service.
 //
 // The `-no-verify` flag allows to skip TLS certificate verification.
 //

--- a/cmd/ndt7-client/main_test.go
+++ b/cmd/ndt7-client/main_test.go
@@ -75,9 +75,9 @@ func TestDownloadError(t *testing.T) {
 	osExit = func(code int) {
 		exitval = code
 	}
-	*flagHostname = "\t" // fail parsing
+	*flagServer = "\t" // fail parsing
 	main()
-	*flagHostname = ""
+	*flagServer = ""
 	osExit = savedFunc
 	if exitval == 0 {
 		t.Fatal("expected nonzero return code here")


### PR DESCRIPTION
The rationale is that when we start using ArgsFromEnv(), the default env variable named HOSTNAME will end up as the flag value, which obviously isn't what we want. It likely wasn't a great naming choice to start with. :)

This is a change [we've already applied to ndt5-client-go](https://github.com/m-lab/ndt5-client-go/pull/10).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/48)
<!-- Reviewable:end -->
