### PR TITLE
Use TCPInfo.MinRTT instead of TCPInfo.RTT

### DIFF
--- a/cmd/ndt7-client/internal/emitter/humanreadable.go
+++ b/cmd/ndt7-client/internal/emitter/humanreadable.go
@@ -88,7 +88,7 @@ func (h HumanReadable) OnSummary(s *Summary) error {
 	_, err := fmt.Fprintf(h.out, summaryFormat,
 		"Server", s.ServerFQDN,
 		"Client", s.ClientIP,
-		"Latency", s.RTT.Value, s.RTT.Unit,
+		"Latency", s.MinRTT.Value, s.MinRTT.Unit,
 		"Download", s.Download.Value, s.Upload.Unit,
 		"Upload", s.Upload.Value, s.Upload.Unit,
 		"Retransmission", s.DownloadRetrans.Value, s.DownloadRetrans.Unit)

--- a/cmd/ndt7-client/internal/emitter/humanreadable_test.go
+++ b/cmd/ndt7-client/internal/emitter/humanreadable_test.go
@@ -242,7 +242,7 @@ func TestHumanReadableOnSummary(t *testing.T) {
 			Value: 1.0,
 			Unit:  "%",
 		},
-		RTT: ValueUnitPair{
+		MinRTT: ValueUnitPair{
 			Value: 10.0,
 			Unit:  "ms",
 		},

--- a/cmd/ndt7-client/internal/emitter/json_test.go
+++ b/cmd/ndt7-client/internal/emitter/json_test.go
@@ -321,7 +321,7 @@ func TestJSONOnSummary(t *testing.T) {
 		output.Download != summary.Download ||
 		output.Upload != summary.Upload ||
 		output.DownloadRetrans != summary.DownloadRetrans ||
-		output.RTT != summary.RTT {
+		output.MinRTT != summary.MinRTT {
 		t.Fatal("OnSummary(): unexpected output")
 	}
 

--- a/cmd/ndt7-client/internal/emitter/summary.go
+++ b/cmd/ndt7-client/internal/emitter/summary.go
@@ -35,7 +35,7 @@ type Summary struct {
 
 	// RTT is the round-trip time of the latest measurement, in milliseconds.
 	// This is provided by the server during a download test.
-	RTT ValueUnitPair
+	MinRTT ValueUnitPair
 }
 
 // NewSummary returns a new Summary struct for a given FQDN.

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -207,7 +207,7 @@ func makeSummary(FQDN string, results map[spec.TestKind]*ndt7.LatestMeasurements
 	}
 
 	// Download comes from the client-side Measurement during the download
-	// test. DownloadRetrans and RTT come from the server-side Measurement,
+	// test. DownloadRetrans and MinRTT come from the server-side Measurement,
 	// if it includes a TCPInfo object.
 	if dl, ok := results[spec.TestDownload]; ok {
 		if dl.Client.AppInfo != nil && dl.Client.AppInfo.ElapsedTime > 0 {
@@ -225,8 +225,8 @@ func makeSummary(FQDN string, results map[spec.TestKind]*ndt7.LatestMeasurements
 					Unit:  "%",
 				}
 			}
-			s.RTT = emitter.ValueUnitPair{
-				Value: float64(dl.Server.TCPInfo.RTT) / 1000,
+			s.MinRTT = emitter.ValueUnitPair{
+				Value: float64(dl.Server.TCPInfo.MinRTT) / 1000,
 				Unit:  "ms",
 			}
 		}

--- a/cmd/ndt7-client/main_test.go
+++ b/cmd/ndt7-client/main_test.go
@@ -369,7 +369,7 @@ func TestMakeSummary(t *testing.T) {
 			Value: 1.0,
 			Unit:  "%",
 		},
-		RTT: emitter.ValueUnitPair{
+		MinRTT: emitter.ValueUnitPair{
 			Value: 10.0,
 			Unit:  "ms",
 		},

--- a/cmd/ndt7-client/main_test.go
+++ b/cmd/ndt7-client/main_test.go
@@ -323,7 +323,7 @@ func TestMakeSummary(t *testing.T) {
 	tcpInfo := &spec.TCPInfo{}
 	tcpInfo.BytesSent = 100
 	tcpInfo.BytesRetrans = 1
-	tcpInfo.RTT = 10000
+	tcpInfo.MinRTT = 10000
 
 	results := map[spec.TestKind]*ndt7.LatestMeasurements{
 		spec.TestDownload: &ndt7.LatestMeasurements{


### PR DESCRIPTION
Show `MinRTT` instead of `RTT` in the test summary. Examples:
```
$ ./ndt7-client -quiet -format=json | jq
{
  "ServerFQDN": "ndt-iupui-mlab1-mil04.mlab-oti.measurement-lab.org",
  "ServerIP": "213.242.77.139",
  "ClientIP": "...",
  "DownloadUUID": "ndt-wnkr5_1589391933_0000000000051384",
  "Download": {
    "Value": 389.681259751377,
    "Unit": "Mbit/s"
  },
  "Upload": {
    "Value": 38.33447624961975,
    "Unit": "Mbit/s"
  },
  "DownloadRetrans": {
    "Value": 0.5296091494852461,
    "Unit": "%"
  },
  "MinRTT": {
    "Value": 22,
    "Unit": "ms"
  }
}
```
```
$ ./ndt7-client -quiet
         Server: ndt-iupui-mlab2-mil04.mlab-oti.measurement-lab.org
         Client: ...
        Latency:    22.0 ms
       Download:   362.8 Mbit/s
         Upload:    45.8 Mbit/s
 Retransmission:    0.76 %
```

Thanks @mattmathis for recommending this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/49)
<!-- Reviewable:end -->
