### PR TITLE
Update clientVersion and libraryVersion

### DIFF
--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -108,7 +108,7 @@ import (
 
 const (
 	clientName     = "ndt7-client-go-cmd"
-	clientVersion  = "0.1.0"
+	clientVersion  = "0.4.1"
 	defaultTimeout = 55 * time.Second
 )
 

--- a/ndt7.go
+++ b/ndt7.go
@@ -32,7 +32,7 @@ const (
 	libraryName = "ndt7-client-go"
 
 	// libraryVersion is the version of this library
-	libraryVersion = "0.1.0"
+	libraryVersion = "0.4.1"
 )
 
 var (


### PR DESCRIPTION
This value is reported in BQ client Metadata. To help with providence, the value should be updated automatically.

Note: I discovered this while looking in BQ to estimate how many clients were still not providing access tokens and looking at the client metadata from those that were not. I found that they were an earlier version of ndt7-client-go, but also realized that there have been several releases since 0.1.0 that might be represented too (but that we could not tell the difference).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/55)
<!-- Reviewable:end -->
