### PR TITLE
Update version to 0.6.1

### DIFF
--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -112,7 +112,7 @@ import (
 
 const (
 	clientName     = "ndt7-client-go-cmd"
-	clientVersion  = "0.5.0"
+	clientVersion  = "0.6.1"
 	defaultTimeout = 55 * time.Second
 )
 

--- a/ndt7.go
+++ b/ndt7.go
@@ -32,7 +32,7 @@ const (
 	libraryName = "ndt7-client-go"
 
 	// libraryVersion is the version of this library
-	libraryVersion = "0.5.0"
+	libraryVersion = "0.6.1"
 )
 
 var (


### PR DESCRIPTION
I forgot to update the clientVersion and libraryVersion before tagging 0.6.0. The 0.6.1 version will just bump the version number correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/68)
<!-- Reviewable:end -->
