### PR TITLE
Use server-side measurements during upload test

### DIFF
--- a/cmd/ndt7-client/internal/emitter/humanreadable_test.go
+++ b/cmd/ndt7-client/internal/emitter/humanreadable_test.go
@@ -88,6 +88,7 @@ func TestHumanReadableOnDownloadEvent(t *testing.T) {
 			NumBytes:    100000000,
 		},
 		Origin: spec.OriginClient,
+		Test:   spec.TestDownload,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -134,12 +135,13 @@ func TestHumanReadableIgnoresServerData(t *testing.T) {
 func TestHumanReadableOnUploadEvent(t *testing.T) {
 	sw := &mocks.SavingWriter{}
 	hr := HumanReadable{sw}
+	tcpInfo := &spec.TCPInfo{}
+	tcpInfo.BytesReceived = 10000000
+	tcpInfo.ElapsedTime = 10000000
 	err := hr.OnUploadEvent(&spec.Measurement{
-		AppInfo: &spec.AppInfo{
-			ElapsedTime: 3000000,
-			NumBytes:    100000000,
-		},
-		Origin: spec.OriginClient,
+		TCPInfo: tcpInfo,
+		Origin:  spec.OriginServer,
+		Test:    spec.TestUpload,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -149,7 +151,7 @@ func TestHumanReadableOnUploadEvent(t *testing.T) {
 	}
 	if !reflect.DeepEqual(
 		sw.Data[0],
-		[]byte("\rAvg. speed  :   266.7 Mbit/s"),
+		[]byte("\rAvg. speed  :     8.0 Mbit/s"),
 	) {
 		t.Fatal("unexpected output")
 	}
@@ -159,22 +161,24 @@ func TestHumanReadableOnUploadEventSafetyCheck(t *testing.T) {
 	sw := &mocks.SavingWriter{}
 	hr := HumanReadable{sw}
 	err := hr.OnUploadEvent(&spec.Measurement{
-		Origin: spec.OriginClient,
+		Origin: spec.OriginServer,
+		Test:   spec.TestUpload,
 	})
 	if err == nil {
 		t.Fatal("We did expect an error here")
 	}
 	if len(sw.Data) != 0 {
-		t.Fatal("Some data was written and it shouldn't have")
+		t.Fatal("Some data was written and it shouldn't have been")
 	}
 }
 
-func TestHumanReadableOnUploadEventDivideByZero(t *testing.T) {
+func TestHumanReadableOnUploadMissingTCPInfo(t *testing.T) {
 	sw := &mocks.SavingWriter{}
 	hr := HumanReadable{sw}
 	err := hr.OnUploadEvent(&spec.Measurement{
 		AppInfo: &spec.AppInfo{},
-		Origin:  spec.OriginClient,
+		Origin:  spec.OriginServer,
+		Test:    spec.TestUpload,
 	})
 	if err == nil {
 		t.Fatal("We did expect an error here")
@@ -186,11 +190,13 @@ func TestHumanReadableOnUploadEventDivideByZero(t *testing.T) {
 
 func TestHumanReadableOnUploadEventFailure(t *testing.T) {
 	hr := HumanReadable{&mocks.FailingWriter{}}
+	tcpInfo := &spec.TCPInfo{}
+	tcpInfo.BytesReceived = 10000000
+	tcpInfo.ElapsedTime = 10000000
 	err := hr.OnUploadEvent(&spec.Measurement{
-		AppInfo: &spec.AppInfo{
-			ElapsedTime: 1234,
-		},
-		Origin: spec.OriginClient,
+		TCPInfo: tcpInfo,
+		Origin:  spec.OriginServer,
+		Test:    spec.TestUpload,
 	})
 	if err != mocks.ErrMocked {
 		t.Fatal("Not the error we expected")

--- a/cmd/ndt7-client/internal/emitter/humanreadable_test.go
+++ b/cmd/ndt7-client/internal/emitter/humanreadable_test.go
@@ -110,9 +110,10 @@ func TestHumanReadableOnDownloadEventFailure(t *testing.T) {
 			ElapsedTime: 1234,
 		},
 		Origin: spec.OriginClient,
+		Test:   spec.TestDownload,
 	})
 	if err != mocks.ErrMocked {
-		t.Fatal("Not the error we expected")
+		t.Fatalf("Not the error we expected: %v", err)
 	}
 }
 

--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -115,9 +115,9 @@ const (
 )
 
 var (
-	ClientName	= "ndt7-client-go-cmd"
-	ClientVersion	= "0.6.1"
-	flagProfile = flag.String("profile", "",
+	ClientName    = "ndt7-client-go-cmd"
+	ClientVersion = "0.6.1"
+	flagProfile   = flag.String("profile", "",
 		"file where to store pprof profile (see https://blog.golang.org/pprof)")
 
 	flagScheme = flagx.Enum{
@@ -273,12 +273,14 @@ func makeSummary(FQDN string, results map[spec.TestKind]*ndt7.LatestMeasurements
 			}
 		}
 	}
-	// Upload comes from the client-side Measurement during the upload test.
+	// The upload rate comes from the receiver (the server). Currently
+	// ndt-server only provides network-level throughput via TCPInfo.
+	// TODO: Use AppInfo for application-level measurements when available.
 	if ul, ok := results[spec.TestUpload]; ok {
-		if ul.Client.AppInfo != nil && ul.Client.AppInfo.ElapsedTime > 0 {
-			elapsed := float64(ul.Client.AppInfo.ElapsedTime) / 1e06
+		if ul.Server.TCPInfo != nil && ul.Server.TCPInfo.BytesReceived > 0 {
+			elapsed := float64(ul.Server.TCPInfo.ElapsedTime) / 1e06
 			s.Upload = emitter.ValueUnitPair{
-				Value: (8.0 * float64(ul.Client.AppInfo.NumBytes)) /
+				Value: (8.0 * float64(ul.Server.TCPInfo.BytesReceived)) /
 					elapsed / (1000.0 * 1000.0),
 				Unit: "Mbit/s",
 			}

--- a/cmd/ndt7-client/main_test.go
+++ b/cmd/ndt7-client/main_test.go
@@ -387,6 +387,9 @@ func TestMakeSummary(t *testing.T) {
 	tcpInfo.BytesSent = 100
 	tcpInfo.BytesRetrans = 1
 	tcpInfo.MinRTT = 10000
+	// Simulate a 8Mb/s upload rate.
+	tcpInfo.BytesReceived = 10000000
+	tcpInfo.ElapsedTime = 10000000
 
 	results := map[spec.TestKind]*ndt7.LatestMeasurements{
 		spec.TestDownload: {
@@ -406,11 +409,8 @@ func TestMakeSummary(t *testing.T) {
 			},
 		},
 		spec.TestUpload: {
-			Client: spec.Measurement{
-				AppInfo: &spec.AppInfo{
-					NumBytes:    100,
-					ElapsedTime: 1,
-				},
+			Server: spec.Measurement{
+				TCPInfo: tcpInfo,
 			},
 		},
 	}
@@ -425,7 +425,7 @@ func TestMakeSummary(t *testing.T) {
 			Unit:  "Mbit/s",
 		},
 		Upload: emitter.ValueUnitPair{
-			Value: 800.0,
+			Value: 8.0,
 			Unit:  "Mbit/s",
 		},
 		DownloadRetrans: emitter.ValueUnitPair{
@@ -441,6 +441,7 @@ func TestMakeSummary(t *testing.T) {
 	generated := makeSummary("test", results)
 
 	if !reflect.DeepEqual(generated, expected) {
+		t.Errorf("expected %+v; got %+v", expected, generated)
 		t.Fatal("makeSummary(): unexpected summary data")
 	}
 }

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -181,7 +181,6 @@ func TestReaderError(t *testing.T) {
 	go func() {
 		for range outch {
 			t.Error("We didn't expect measurements here")
-			return
 		}
 	}()
 	err := Run(ctx, &conn, outch)
@@ -222,7 +221,6 @@ func TestReadInvalidJSON(t *testing.T) {
 	go func() {
 		for range outch {
 			t.Error("We didn't expect measurements here")
-			return
 		}
 	}()
 	err := Run(ctx, &conn, outch)

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -92,10 +92,12 @@ func TestReadBinary(t *testing.T) {
 		NextReaderMessageType: websocket.BinaryMessage,
 		MessageByteArray:      []byte("12345678"),
 	}
-	errch := make(chan error, 1)
-	go func(errch chan<- error) {
-		errch <- Run(ctx, &conn, outch)
-	}(errch)
+	go func() {
+		err := Run(ctx, &conn, outch)
+		if err != nil {
+			t.Errorf("error: %v", err)
+		}
+	}()
 	prev := spec.Measurement{
 		AppInfo: &spec.AppInfo{},
 	}
@@ -117,9 +119,6 @@ func TestReadBinary(t *testing.T) {
 		}
 		prev = m
 	}
-	if err := <-errch; err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestSetReadDeadlineError(t *testing.T) {
@@ -134,20 +133,14 @@ func TestSetReadDeadlineError(t *testing.T) {
 		MessageByteArray:      []byte("{}"),
 		SetReadDeadlineResult: mockedErr,
 	}
-	errch := make(chan error, 1)
-	go func(errch chan<- error) {
+	go func() {
 		for range outch {
-			errch <- errors.New("We didn't expect measurements here")
-			return
+			t.Error("We didn't expect measurements here")
 		}
-		errch <- nil
-	}(errch)
+	}()
 	err := Run(ctx, &conn, outch)
 	if err != mockedErr {
 		t.Fatal("Not the error that we were expecting")
-	}
-	if err := <-errch; err != nil {
-		t.Fatal(err)
 	}
 }
 
@@ -163,20 +156,14 @@ func TestReadMessageError(t *testing.T) {
 		MessageByteArray:      []byte("{}"),
 		NextReaderResult:      mockedErr,
 	}
-	errch := make(chan error, 1)
-	go func(errch chan<- error) {
+	go func() {
 		for range outch {
-			errch <- errors.New("We didn't expect measurements here")
-			return
+			t.Error("We didn't expect measurements here")
 		}
-		errch <- nil
-	}(errch)
+	}()
 	err := Run(ctx, &conn, outch)
 	if err != mockedErr {
 		t.Fatal("Not the error that we were expecting")
-	}
-	if err := <-errch; err != nil {
-		t.Fatal(err)
 	}
 }
 
@@ -191,20 +178,15 @@ func TestReaderError(t *testing.T) {
 		NextReaderMessageType: websocket.TextMessage,
 		NextReaderMustFail:    true,
 	}
-	errch := make(chan error, 1)
-	go func(errch chan<- error) {
+	go func() {
 		for range outch {
-			errch <- errors.New("We didn't expect measurements here")
+			t.Error("We didn't expect measurements here")
 			return
 		}
-		errch <- nil
-	}(errch)
+	}()
 	err := Run(ctx, &conn, outch)
 	if err != mocks.ErrReadFailed {
 		t.Fatal("Not the error that we were expecting")
-	}
-	if err := <-errch; err != nil {
-		t.Fatal(err)
 	}
 	// Test when type is websocket.BinaryMessage
 	outch = make(chan spec.Measurement)
@@ -216,20 +198,14 @@ func TestReaderError(t *testing.T) {
 		NextReaderMessageType: websocket.BinaryMessage,
 		NextReaderMustFail:    true,
 	}
-	errch = make(chan error, 1)
-	go func(errch chan<- error) {
+	go func() {
 		for range outch {
-			errch <- errors.New("We didn't expect measurements here")
-			return
+			t.Error("We didn't expect measurements here")
 		}
-		errch <- nil
-	}(errch)
+	}()
 	err = Run(ctx, &conn, outch)
 	if err != mocks.ErrReadFailed {
 		t.Fatal("Not the error that we were expecting")
-	}
-	if err := <-errch; err != nil {
-		t.Fatal(err)
 	}
 }
 
@@ -243,19 +219,14 @@ func TestReadInvalidJSON(t *testing.T) {
 		NextReaderMessageType: websocket.TextMessage,
 		MessageByteArray:      []byte("{"),
 	}
-	errch := make(chan error, 1)
-	go func(errch chan<- error) {
+	go func() {
 		for range outch {
-			errch <- errors.New("We didn't expect measurements here")
+			t.Error("We didn't expect measurements here")
 			return
 		}
-		errch <- nil
-	}(errch)
+	}()
 	err := Run(ctx, &conn, outch)
 	if err == nil {
 		t.Fatal("We expected to have an error here")
-	}
-	if err := <-errch; err != nil {
-		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This change makes the client compute the upload rate via the `TCPInfo` objects periodically sent by the server.

Client-side measurements had been used in the initial implementation since counterflow message processing wasn't implemented yet (see #38) and server-side measurement were not available.

Ideally this should use `AppInfo` to consistently compute application-level rates in both download and upload, but `AppInfo` isn't currently sent by ndt-server. For now, showing a server-side network-level measurement is better than a client-side application-level measurement which will be overestimated on slow links (see #74).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/75)
<!-- Reviewable:end -->
