### PR TITLE
Show latency on upload-only measurements

### DIFF
--- a/internal/emitter/humanreadable.go
+++ b/internal/emitter/humanreadable.go
@@ -91,43 +91,48 @@ func (h HumanReadable) OnComplete(test spec.TestKind) error {
 
 // OnSummary handles the summary event.
 func (h HumanReadable) OnSummary(s *Summary) error {
-	const summaryFormat = `%15s: %s
-%15s: %s
+	const summaryHeaderFormat = `
+Test results
+
+%10s: %s
+%10s: %s
+`
+	const downloadFormat = `
+%22s
+%15s: %7.1f %s
+%15s: %7.1f %s
 %15s: %7.1f %s
 `
-	_, err := fmt.Fprintf(h.out, summaryFormat,
+	const uploadFormat = `
+%20s
+%15s: %7.1f %s
+%15s: %7.1f %s
+`
+	_, err := fmt.Fprintf(h.out, summaryHeaderFormat,
 		"Server", s.ServerFQDN,
-		"Client", s.ClientIP,
-		"Latency", s.MinRTT.Value, s.MinRTT.Unit)
+		"Client", s.ClientIP)
 	if err != nil {
 		return err
 	}
 
-	if s.Download.Value != 0.0 {
-		_, err := fmt.Fprintf(h.out, "%15s: %7.1f %s\n",
-			"Download", s.Download.Value, s.Download.Unit)
+	if s.Download != nil {
+		_, err := fmt.Fprintf(h.out, downloadFormat, "Download",
+			"Throughput", s.Download.Throughput.Value, s.Download.Throughput.Unit,
+			"Latency", s.Download.Latency.Value, s.Download.Latency.Unit,
+			"Retransmission", s.Download.Retransmission.Value, s.Download.Retransmission.Unit)
 		if err != nil {
 			return err
 		}
 	}
 
-	if s.Upload.Value != 0.0 {
-		_, err := fmt.Fprintf(h.out, "%15s: %7.1f %s\n",
-			"Upload", s.Upload.Value, s.Upload.Unit)
+	if s.Upload != nil {
+		_, err := fmt.Fprintf(h.out, uploadFormat, "Upload",
+			"Throughput", s.Upload.Throughput.Value, s.Upload.Throughput.Unit,
+			"Latency", s.Upload.Latency.Value, s.Upload.Latency.Unit)
 		if err != nil {
 			return err
 		}
 	}
-
-	if s.DownloadRetrans.Value != 0.0 {
-		_, err := fmt.Fprintf(h.out, "%15s: %7.2f %s\n",
-			"Retransmission", s.DownloadRetrans.Value, s.DownloadRetrans.Unit)
-		if err != nil {
-			return err
-		}
-	}
-
-	fmt.Fprintln(h.out)
 
 	return nil
 }

--- a/internal/emitter/humanreadable.go
+++ b/internal/emitter/humanreadable.go
@@ -94,20 +94,40 @@ func (h HumanReadable) OnSummary(s *Summary) error {
 	const summaryFormat = `%15s: %s
 %15s: %s
 %15s: %7.1f %s
-%15s: %7.1f %s
-%15s: %7.1f %s
-%15s: %7.2f %s
 `
 	_, err := fmt.Fprintf(h.out, summaryFormat,
 		"Server", s.ServerFQDN,
 		"Client", s.ClientIP,
-		"Latency", s.MinRTT.Value, s.MinRTT.Unit,
-		"Download", s.Download.Value, s.Upload.Unit,
-		"Upload", s.Upload.Value, s.Upload.Unit,
-		"Retransmission", s.DownloadRetrans.Value, s.DownloadRetrans.Unit)
+		"Latency", s.MinRTT.Value, s.MinRTT.Unit)
 	if err != nil {
 		return err
 	}
+
+	if s.Download.Value != 0.0 {
+		_, err := fmt.Fprintf(h.out, "%15s: %7.1f %s\n",
+			"Download", s.Download.Value, s.Download.Unit)
+		if err != nil {
+			return err
+		}
+	}
+
+	if s.Upload.Value != 0.0 {
+		_, err := fmt.Fprintf(h.out, "%15s: %7.1f %s\n",
+			"Upload", s.Upload.Value, s.Upload.Unit)
+		if err != nil {
+			return err
+		}
+	}
+
+	if s.DownloadRetrans.Value != 0.0 {
+		_, err := fmt.Fprintf(h.out, "%15s: %7.2f %s\n",
+			"Retransmission", s.DownloadRetrans.Value, s.DownloadRetrans.Unit)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintln(h.out)
 
 	return nil
 }

--- a/internal/emitter/humanreadable_test.go
+++ b/internal/emitter/humanreadable_test.go
@@ -2,7 +2,6 @@ package emitter
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -230,9 +229,6 @@ func TestHumanReadableOnSummary(t *testing.T) {
 	expected := `         Server: test
          Client: test
         Latency:    10.0 ms
-       Download:   100.0 Mbit/s
-         Upload:   100.0 Mbit/s
- Retransmission:    1.00 %
 `
 	summary := &Summary{
 		ClientIP:   "test",
@@ -261,12 +257,11 @@ func TestHumanReadableOnSummary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(sw.Data) != 1 {
-		t.Fatal("invalid length")
+	if len(sw.Data) == 0 {
+		t.Fatal("no data written")
 	}
+
 	if string(sw.Data[0]) != expected {
-		fmt.Println(string(sw.Data[0]))
-		fmt.Println(expected)
 		t.Fatal("OnSummary(): unexpected data")
 	}
 }

--- a/internal/emitter/humanreadable_test.go
+++ b/internal/emitter/humanreadable_test.go
@@ -226,28 +226,49 @@ func TestHumanReadableOnCompleteFailure(t *testing.T) {
 }
 
 func TestHumanReadableOnSummary(t *testing.T) {
-	expected := `         Server: test
-         Client: test
+	expectedHeader := `
+Test results
+
+    Server: test
+    Client: test
+`
+	expectedUpload := `
+              Upload
+     Throughput:   100.0 Mbit/s
         Latency:    10.0 ms
+`
+	expectedDownload := `
+              Download
+     Throughput:   100.0 Mbit/s
+        Latency:    10.0 ms
+ Retransmission:     1.0 %
 `
 	summary := &Summary{
 		ClientIP:   "test",
 		ServerFQDN: "test",
-		Download: ValueUnitPair{
-			Value: 100.0,
-			Unit:  "Mbit/s",
+		Download: &SubtestSummary{
+			Throughput: ValueUnitPair{
+				Value: 100.0,
+				Unit:  "Mbit/s",
+			},
+			Latency: ValueUnitPair{
+				Value: 10.0,
+				Unit:  "ms",
+			},
+			Retransmission: ValueUnitPair{
+				Value: 1.0,
+				Unit:  "%",
+			},
 		},
-		Upload: ValueUnitPair{
-			Value: 100.0,
-			Unit:  "Mbit/s",
-		},
-		DownloadRetrans: ValueUnitPair{
-			Value: 1.0,
-			Unit:  "%",
-		},
-		MinRTT: ValueUnitPair{
-			Value: 10.0,
-			Unit:  "ms",
+		Upload: &SubtestSummary{
+			Throughput: ValueUnitPair{
+				Value: 100.0,
+				Unit:  "Mbit/s",
+			},
+			Latency: ValueUnitPair{
+				Value: 10.0,
+				Unit:  "ms",
+			},
 		},
 	}
 	sw := &mocks.SavingWriter{}
@@ -261,7 +282,9 @@ func TestHumanReadableOnSummary(t *testing.T) {
 		t.Fatal("no data written")
 	}
 
-	if string(sw.Data[0]) != expected {
+	if string(sw.Data[0]) != expectedHeader ||
+		string(sw.Data[1]) != expectedDownload ||
+		string(sw.Data[2]) != expectedUpload {
 		t.Fatal("OnSummary(): unexpected data")
 	}
 }

--- a/internal/emitter/json_test.go
+++ b/internal/emitter/json_test.go
@@ -317,11 +317,8 @@ func TestJSONOnSummary(t *testing.T) {
 	if output.ClientIP != summary.ClientIP ||
 		output.ServerFQDN != summary.ServerFQDN ||
 		output.ServerIP != summary.ServerIP ||
-		output.DownloadUUID != summary.DownloadUUID ||
 		output.Download != summary.Download ||
-		output.Upload != summary.Upload ||
-		output.DownloadRetrans != summary.DownloadRetrans ||
-		output.MinRTT != summary.MinRTT {
+		output.Upload != summary.Upload {
 		t.Fatal("OnSummary(): unexpected output")
 	}
 

--- a/internal/emitter/summary.go
+++ b/internal/emitter/summary.go
@@ -6,6 +6,16 @@ type ValueUnitPair struct {
 	Unit  string
 }
 
+type SubtestSummary struct {
+	UUID       string
+	Throughput ValueUnitPair
+	// Latency is the MinRTT value of the latest measurement, in milliseconds.
+	// For uploads, this is provided by the server.
+	Latency ValueUnitPair
+	// Retransmission is BytesRetrans / BytesSent from TCPInfo
+	Retransmission ValueUnitPair
+}
+
 // Summary is a struct containing the values displayed to the user at
 // the end of an ndt7 test.
 type Summary struct {
@@ -18,24 +28,8 @@ type Summary struct {
 	// ClientIP is the (v4 or v6) IP address of the client.
 	ClientIP string
 
-	// DownloadUUID is the UUID of the download test.
-	// TODO: add UploadUUID after we start processing counterflow messages.
-	DownloadUUID string
-
-	// Download is the download speed, in Mbit/s. This is measured at the
-	// receiver.
-	Download ValueUnitPair
-
-	// Upload is the upload speed, in Mbit/s. This is measured at the sender.
-	Upload ValueUnitPair
-
-	// DownloadRetrans is the retransmission rate. This is based on the TCPInfo
-	// values provided by the server during a download test.
-	DownloadRetrans ValueUnitPair
-
-	// RTT is the round-trip time of the latest measurement, in milliseconds.
-	// This is provided by the server during a download test.
-	MinRTT ValueUnitPair
+	Download *SubtestSummary
+	Upload   *SubtestSummary
 }
 
 // NewSummary returns a new Summary struct for a given FQDN.

--- a/internal/emitter/summary.go
+++ b/internal/emitter/summary.go
@@ -6,11 +6,14 @@ type ValueUnitPair struct {
 	Unit  string
 }
 
+// SubtestSummary contains all the results of a single subtest (download or
+// upload). All the values are from the server's perspective.
 type SubtestSummary struct {
-	UUID       string
+	// UUID is the unique identified of this subtest.
+	UUID string
+	// Throughput is the measured throughput during this subtest.
 	Throughput ValueUnitPair
 	// Latency is the MinRTT value of the latest measurement, in milliseconds.
-	// For uploads, this is provided by the server.
 	Latency ValueUnitPair
 	// Retransmission is BytesRetrans / BytesSent from TCPInfo
 	Retransmission ValueUnitPair
@@ -28,8 +31,11 @@ type Summary struct {
 	// ClientIP is the (v4 or v6) IP address of the client.
 	ClientIP string
 
+	// Download is a summary of the download subtest.
 	Download *SubtestSummary
-	Upload   *SubtestSummary
+
+	// Upload is a summary of the upload subtest.
+	Upload *SubtestSummary
 }
 
 // NewSummary returns a new Summary struct for a given FQDN.

--- a/internal/emitter/summary.go
+++ b/internal/emitter/summary.go
@@ -7,7 +7,8 @@ type ValueUnitPair struct {
 }
 
 // SubtestSummary contains all the results of a single subtest (download or
-// upload). All the values are from the server's perspective.
+// upload). All the values are from the server's perspective, except for the
+// download throughput.
 type SubtestSummary struct {
 	// UUID is the unique identified of this subtest.
 	UUID string

--- a/internal/mocks/writer.go
+++ b/internal/mocks/writer.go
@@ -23,6 +23,8 @@ type SavingWriter struct {
 
 // Write appends data to sw.Data. It never fails.
 func (sw *SavingWriter) Write(data []byte) (int, error) {
-	sw.Data = append(sw.Data, data)
+	d := make([]byte, len(data))
+	copy(d, data)
+	sw.Data = append(sw.Data, d)
 	return len(data), nil
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-lab/go/testingx"
 	"github.com/m-lab/go/memoryless"
+	"github.com/m-lab/go/testingx"
 	"github.com/m-lab/locate/api/locate"
 	"github.com/m-lab/ndt-server/ndt7/ndt7test"
 	"github.com/m-lab/ndt7-client-go"
@@ -274,7 +274,7 @@ func TestBatchEmitterEventsOrderFailure(t *testing.T) {
 // We hijack the channel in a memoryless.Ticker to allow us to count the
 // number of ticks consumed (and skip the waits).
 type countingTicker struct {
-	ticker *memoryless.Ticker
+	ticker    *memoryless.Ticker
 	waitCount int
 	writeChan chan<- time.Time
 	countChan chan int
@@ -283,7 +283,7 @@ type countingTicker struct {
 func newCountingTicker(countChan chan int) *countingTicker {
 	c := make(chan time.Time)
 	ticker := &countingTicker{
-		ticker: &memoryless.Ticker{C: c},
+		ticker:    &memoryless.Ticker{C: c},
 		waitCount: 0,
 		writeChan: c,
 		countChan: countChan,
@@ -321,11 +321,11 @@ func TestRunTestsInLoopDaemon(t *testing.T) {
 
 	runner := Runner{
 		emitter: mockedEmitter{},
-		ticker: ticker.ticker,
+		ticker:  ticker.ticker,
 		opt: RunnerOptions{
-			Download: false,  // skip download test
-			Upload: false,  // skip upload test
-			Timeout: 55 * time.Second, 
+			Download: false, // skip download test
+			Upload:   false, // skip upload test
+			Timeout:  55 * time.Second,
 			ClientFactory: func() *ndt7.Client {
 				client := ndt7.NewClient(ClientName, ClientVersion)
 				client.ServiceURL = url
@@ -368,7 +368,7 @@ func TestMakeSummary(t *testing.T) {
 			ConnectionInfo: &spec.ConnectionInfo{
 				Client: "127.0.0.1:12345",
 				Server: "127.0.0.2:443",
-				UUID:   "test-uuid",
+				UUID:   "test-download-uuid",
 			},
 			Server: spec.Measurement{
 				TCPInfo: tcpInfo,
@@ -378,29 +378,43 @@ func TestMakeSummary(t *testing.T) {
 			Server: spec.Measurement{
 				TCPInfo: tcpInfo,
 			},
+			ConnectionInfo: &spec.ConnectionInfo{
+				Client: "127.0.0.1:12345",
+				Server: "127.0.0.2:443",
+				UUID:   "test-upload-uuid",
+			},
 		},
 	}
 
 	expected := &emitter.Summary{
-		ServerFQDN:   "test",
-		ClientIP:     "127.0.0.1",
-		ServerIP:     "127.0.0.2",
-		DownloadUUID: "test-uuid",
-		Download: emitter.ValueUnitPair{
-			Value: 800.0,
-			Unit:  "Mbit/s",
+		ServerFQDN: "test",
+		ClientIP:   "127.0.0.1",
+		ServerIP:   "127.0.0.2",
+		Download: &emitter.SubtestSummary{
+			UUID: "test-download-uuid",
+			Throughput: emitter.ValueUnitPair{
+				Value: 800.0,
+				Unit:  "Mbit/s",
+			},
+			Latency: emitter.ValueUnitPair{
+				Value: 10.0,
+				Unit:  "ms",
+			},
+			Retransmission: emitter.ValueUnitPair{
+				Value: 1.0,
+				Unit:  "%",
+			},
 		},
-		Upload: emitter.ValueUnitPair{
-			Value: 8.0,
-			Unit:  "Mbit/s",
-		},
-		DownloadRetrans: emitter.ValueUnitPair{
-			Value: 1.0,
-			Unit:  "%",
-		},
-		MinRTT: emitter.ValueUnitPair{
-			Value: 10.0,
-			Unit:  "ms",
+		Upload: &emitter.SubtestSummary{
+			UUID: "test-upload-uuid",
+			Throughput: emitter.ValueUnitPair{
+				Value: 8.0,
+				Unit:  "Mbit/s",
+			},
+			Latency: emitter.ValueUnitPair{
+				Value: 10.0,
+				Unit:  "ms",
+			},
 		},
 	}
 

--- a/ndt7.go
+++ b/ndt7.go
@@ -135,10 +135,7 @@ func makeUserAgent(clientName, clientVersion string) string {
 // clientName and clientVersion. M-Lab services may reject requests coming
 // from clients that do not identify themselves properly.
 func NewClient(clientName, clientVersion string) *Client {
-	results := map[spec.TestKind]*LatestMeasurements{
-		spec.TestDownload: {},
-		spec.TestUpload:   {},
-	}
+	results := map[spec.TestKind]*LatestMeasurements{}
 	return &Client{
 		ClientName:    clientName,
 		ClientVersion: clientVersion,
@@ -289,11 +286,13 @@ func (c *Client) collectData(ctx context.Context, f testFn, conn websocketx.Conn
 // is that, if you did not specify a server FQDN, we will discover a server
 // for you and store that value into the c.FQDN field.
 func (c *Client) StartDownload(ctx context.Context) (<-chan spec.Measurement, error) {
+	c.results[spec.TestDownload] = &LatestMeasurements{}
 	return c.start(ctx, c.download, params.DownloadURLPath)
 }
 
 // StartUpload is like StartDownload but for the upload.
 func (c *Client) StartUpload(ctx context.Context) (<-chan spec.Measurement, error) {
+	c.results[spec.TestUpload] = &LatestMeasurements{}
 	return c.start(ctx, c.upload, params.UploadURLPath)
 }
 


### PR DESCRIPTION
This PR changes the summary generation to display the latency from the server's TCPInfo after an upload-only test.

It also hides Retransmission in this case (since there is no way for the client to know it without accessing TCPInfo) and makes sure the client IP is always shown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/82)
<!-- Reviewable:end -->
