### PR TITLE
Add source IP flag and implementation

### DIFF
--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -234,7 +234,7 @@ func main() {
 				}
 				if parsedIp != nil {
 					c.Dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-						fmt.Printf("INFO: using source IP: %s\n", parsedIp.String())
+						fmt.Printf("\nINFO: using source IP: %s\n", parsedIp.String())
 						dialer := net.Dialer{LocalAddr: &net.TCPAddr{IP: parsedIp}}
 						return dialer.DialContext(ctx, network, addr)
 					}


### PR DESCRIPTION
This PR adds a "source" flag to the ndt7 client to allow running the test on a specific interface.