### PR TITLE
Send measurement if the test ended before UpdateInterval

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -39,8 +39,8 @@ func Run(ctx context.Context, conn websocketx.Conn, ch chan<- spec.Measurement) 
 		mtype, r, err := conn.NextReader()
 		if err != nil {
 			elapsed := time.Now().Sub(start)
-			// If test finished before `params.UpdateInterval` and at least one message
-			// has been received, send its data before exiting.
+			// If the test finished before `params.UpdateInterval` and at least one message
+			// has been received, send the measurement data through the channel before exiting.
 			if elapsed <= params.UpdateInterval && total > 0 {
 				sendMeasurement(ch, elapsed, total)
 			}


### PR DESCRIPTION
This PR adds functionality to send the measurement through the channel if one is received before `params.UpdateInterval`. It used to not be likely that a test would terminate before said interval, but this is now possible with the early-exit changes to the server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/92)
<!-- Reviewable:end -->
