### PR TITLE
Service URLs may have a prefix

### DIFF
--- a/cmd/ndt7-client/main.go
+++ b/cmd/ndt7-client/main.go
@@ -184,10 +184,10 @@ func main() {
 	}
 
 	// If a service URL is given, then only one direction is possible.
-	if flagService.URL != nil && strings.Contains(flagService.URL.Path, params.DownloadURLPath) {
+	if flagService.URL != nil && strings.HasSuffix(flagService.URL.Path, params.DownloadURLPath) {
 		*flagUpload = false
 		*flagDownload = true
-	} else if flagService.URL != nil && strings.Contains(flagService.URL.Path, params.UploadURLPath) {
+	} else if flagService.URL != nil && strings.HasSuffix(flagService.URL.Path, params.UploadURLPath) {
 		*flagUpload = true
 		*flagDownload = false
 	} else if flagService.URL != nil {

--- a/ndt7.go
+++ b/ndt7.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -229,7 +230,7 @@ func (c *Client) start(ctx context.Context, f testFn, p string) (<-chan spec.Mea
 		}
 	}
 	// Second, check for the service url.
-	if c.ServiceURL != nil && (c.ServiceURL.Path == params.DownloadURLPath || c.ServiceURL.Path == params.UploadURLPath) {
+	if c.ServiceURL != nil && (strings.HasSuffix(c.ServiceURL.Path, params.DownloadURLPath) || strings.HasSuffix(c.ServiceURL.Path, params.UploadURLPath)) {
 		// Override scheme to match the provided service url.
 		c.Scheme = c.ServiceURL.Scheme
 		customURL = c.ServiceURL


### PR DESCRIPTION
An example of this would be if the service is hosted behind some load balancer, or as a part of a larger service where there's a prefix .

This change makes the client a little more lenient, allowing for something like:

    go run ./cmd/ndt7-client/main.go -service-url 'wss://speedtest.example.com/some-prefix/ndt/v7/upload'

cc @pthankappan

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-go/97)
<!-- Reviewable:end -->
